### PR TITLE
Add new resized target option "w400"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.0.3
+- Add a new resized target option: w400
+
 ### 2.0.2
 - Set Cache-Control: no-store in the response header for oauth endpoints 
 - Sort EditorPicksSection by updated_at field in controllers/index_page.go

--- a/models/asset.go
+++ b/models/asset.go
@@ -36,6 +36,7 @@ type ResizedTargets struct {
 	Tiny    ImageAsset `bson:"tiny" json:"tiny"`
 	Desktop ImageAsset `bson:"desktop" json:"desktop"`
 	Tablet  ImageAsset `bson:"tablet" json:"tablet"`
+	W400    ImageAsset `bson:"w400 json:"w400"`
 }
 
 // Image is used to return in response

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -162,6 +162,11 @@ func SetMgoDefaultRecords() {
 					Width:  80,
 					URL:    "https://www.twreporter.org/images/mock-image-1-tiny.jpg",
 				},
+				W400: models.ImageAsset{
+					Height: 300,
+					Width:  400,
+					URL:    "https://www.twreporter.org/images/mock-image-1-w400.jpg",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This patch introduces new resized target option "w400" to improve
the hero image utilization.