### PR TITLE
New endpoint for subscribing webpush notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ It provides several RESTful web services, including
 - [Read the combination of sections on index page](https://github.com/twreporter/go-api#read-posts-of-latest-editor-picked-latest-topic-reviews-topics-photography-and-infographic-sections-of-index-page)
 - [Read the posts of multiple categories on index page](https://github.com/twreporter/go-api#read-posts-of-character-culture_movie-human_rights-international-land_environment-photo_audio-political_society-and-transformed_justice-categories)
 - [Create/Read/Update/Delete bookmarks of a user](https://github.com/twreporter/go-api#bookmarks)
+- [Create/Read a web push subscription](https://github.com/twreporter/go-api#web-push-subscriptions)
 - [Create/Read/Update/Delete registration(s)](https://github.com/twreporter/go-api#registrations)
 - [Create/Read/Update/Delete service(s)](https://github.com/twreporter/go-api#services)
 
@@ -514,6 +515,108 @@ Before Oauth signin, you have to setup the oauth config in `configs/config.json`
   **Content:** `{"status": "Record not found", "error": "${here_goes_error_msg}"}`
   * **Code:** 500 <br />
   **Content:** `{"status": "Internal server error", "error": "${here_goes_error_msg}"}`
+
+## WEB PUSH SUBSCRIPTIONS
+### Read a web push subscription
+- Method: `GET`
+- URL: `/v1/web-push/subscriptions`
+- URL Param: 
+  * Required: 
+    `
+    ednpoint=[string] 
+    `
+  * example: 
+    `/v1/web-push/subscriptions?endpoint=https://fcm.googleapis.com/fcm/send/cHB8zjJfX14:APA91bGYoY_R4trCoq2-94pDVUoHcLajBVwaBTkRzJ3q7QiykGXWQW6xN1k7JMUYP4qfgLnRknmQ03WrirHf1eJdR1GHLLmxhX9ZgrZIwb2_mbatDI0Uervod0i5dw_8xRX9TnVms4t8`
+
+- Response: 
+  * **Code:** 200 <br />
+    **Content:**
+    ```
+    {
+      "status": "success",
+      "data": {
+        "id": 1,
+        "created_at": "2018-05-21T10:42:58Z",
+        "updated_at": "2018-05-21T10:42:58Z",
+        "deleted_at": null,
+        "endpoint": "https://fcm.googleapis.com/fcm/send/cHB8zjJfX14:APA91bGYoY_R4trCoq2-94pDVUoHcLajBVwaBTkRzJ3q7QiykGXWQW6xN1k7JMUYP4qfgLnRknmQ03WrirHf1eJdR1GHLLmxhX9ZgrZIwb2_mbatDI0Uervod0i5dw_8xRX9TnVms4t8",
+        "hash_endpoint": "709c44db8951ece74e1893ba558efefa",
+        "expiration_time": null,
+        "user_id": null
+      }
+    }
+    ```
+  * **Code:** 404 <br />
+    **Content:**
+    ```
+    {
+      "status": "error",
+      "message": "Fail to get a web push subscription"
+    }
+    ```
+  * **Code:** 500 <br />
+    **Content:** 
+    ```
+    {
+      "status": "error", 
+      "message": "${here_goes_error_msg}"
+    }
+    ```
+
+### Create a web push subscription
+- URL: `/v1/web-push/subscriptions`
+- Content-Type of Header: `application/json` or `application/x-www-form-urlencoded`
+- Method: `POST`
+- Data Params:
+  * Required:  
+    `endpoint: [string]`<br/>
+    `keys: [string]`
+  * Optional:
+    `expiration_time: [string|null]`<br/>
+    `user_id: [string|null]`
+```
+// Content-Type: application/json
+{
+  "endpoint": "https://fcm.googleapis.com/fcm/send/f4Stnx6WC5s:APA91bFGo-JD8bDwezv1fx3RRyBVq6XxOkYIo8_7vCAJ3HFHLppKAV6GNmOIZLH0YeC2lM_Ifs9GkLK8Vi_8ASEYLBC1aU9nJy2rZSUfH7DE0AqIIbLrs93SdEdkwr5uL6skPMjJsMRQ",
+  "keys": "{\"p256dh\":\"BDmY8OGe-LfW0ENPIADvmdZMo3GfX2J2yqURpsDOn5tT8lQV-VVHyhRUgzjnmx_RRoobwdLULdBr26oULtLML3w\",\"auth\":\"P_AJ9QSqcgM-KJi_GRN3fQ\"}",
+  "expiration_time": "1526959900",
+  "user_id": "2"
+}
+```
+- Response: 
+  * **Code:** 201 <br />
+    **Content:**
+    ```
+    {
+      "data": {
+        "endpoint": "https://fcm.googleapis.com/fcm/send/f4Stnx6WC5s:APA91bFGo-JD8bDwezv1fx3RRyBVq6XxOkYIo8_7vCAJ3HFHLppKAV6GNmOIZLH0YeC2lM_Ifs9GkLK8Vi_8ASEYLBC1aU9nJy2rZSUfH7DE0AqIIbLrs93SdEdkwr5uL6skPMjJsMRQ",
+        "keys": "{\"p256dh\":\"BDmY8OGe-LfW0ENPIADvmdZMo3GfX2J2yqURpsDOn5tT8lQV-VVHyhRUgzjnmx_RRoobwdLULdBr26oULtLML3w\",\"auth\":\"P_AJ9QSqcgM-KJi_GRN3fQ\"}",
+        "expiration_time": "1526959900",
+        "user_id": "2",
+      },
+      "status": "success"
+    }
+    ```
+  * **Code:** 400 <br />
+    **Content:** 
+    ```
+    {
+      "data": {
+        "endpoint": "endpoint is required, and need to be a string",
+        "keys": "keys is required, and need to be a string",
+        "expiration_time": "expirationTime is optional, if provide, need to be a string of timestamp",
+        "user_id": "user_id is optional, if provide, need to be a string",
+      },
+      "status": "fail"
+    ```
+  * **Code:** 500 <br />
+    **Content:** 
+    ```
+    {
+      "status": "error", 
+      "message": "${here_goes_error_msg}"
+    }
+    ```
 
 ## SERVICES
 ### Create a service

--- a/controllers/membership.go
+++ b/controllers/membership.go
@@ -63,6 +63,10 @@ func (mc *MembershipController) SetRoute(group *gin.RouterGroup) *gin.RouterGrou
 	group.POST("/users/:userID/bookmarks", middlewares.CheckJWT(), middlewares.ValidateUserID(), middlewares.SetCacheControl("no-store"), mc.CreateABookmarkOfAUser)
 	group.DELETE("/users/:userID/bookmarks/:bookmarkID", middlewares.CheckJWT(), middlewares.ValidateUserID(), middlewares.SetCacheControl("no-store"), mc.DeleteABookmarkOfAUser)
 
+	// endpoints for web push subscriptions
+	group.POST("/web-push/subscriptions" /*middlewares.CheckJWT()*/, GinResponseWrapper(mc.SubscribeWebPush))
+	group.GET("/web-push/subscriptions", GinResponseWrapper(mc.IsWebPushSubscribed))
+
 	// endpoint for registration
 	// TODO add middleware to check the request from twreporter.org domain
 	group.POST("/registrations/:service", mc.Register)

--- a/controllers/subscription.go
+++ b/controllers/subscription.go
@@ -1,0 +1,95 @@
+package controllers
+
+import (
+	"crypto/md5"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	//log "github.com/Sirupsen/logrus"
+	"github.com/gin-gonic/gin"
+	"twreporter.org/go-api/models"
+)
+
+// IsWebPushSubscribed - which handles the HTTP Get request,
+// and try to check if the web push subscription is existed or not
+func (mc *MembershipController) IsWebPushSubscribed(c *gin.Context) (int, gin.H, error) {
+	const errorWhere = "MembershipController.IsWebPushSubscribed"
+	var endpoint = c.Query("endpoint")
+	var err error
+	var hashEndpoint string
+	var wpSub models.WebPushSubscription
+
+	if endpoint == "" {
+		return http.StatusNotFound, gin.H{"status": "error", "message": "Fail to get a web push subscription since you do not provide endpoint in URL query param"}, nil
+	}
+
+	hashEndpoint = fmt.Sprintf("%x", md5.Sum([]byte(endpoint)))
+
+	if wpSub, err = mc.Storage.GetAWebPushSubscriptionByHashEndpoint(hashEndpoint); err != nil {
+		switch appErr := err.(type) {
+		case models.AppError:
+			return 0, gin.H{}, models.NewAppError(errorWhere, "Fail to get a web push subscription", appErr.Error(), appErr.StatusCode)
+		default:
+			return http.StatusInternalServerError, gin.H{"status": "error", "message": "Unknown Error Type. Fail to get a web push subscription"}, nil
+		}
+	}
+
+	return http.StatusOK, gin.H{"status": "success", "data": wpSub}, nil
+}
+
+// SubscribeWebPush - which handles the HTTP POST request,
+// and try to create a web push subscription record into the persistent database
+func (mc *MembershipController) SubscribeWebPush(c *gin.Context) (int, gin.H, error) {
+	// subscriptionBody is to store POST body
+	type subscriptionBody struct {
+		Endpoint       string `json:"endpoint" form:"endpoint" binding:"required"`
+		Keys           string `json:"keys" form:"keys" binding:"required"`
+		ExpirationTime string `json:"expirationTime" form:"expirationTime"`
+		UserID         string `json:"user_id" form:"user_id"`
+	}
+
+	const errorWhere = "MembershipController.SubscribeWebPush"
+	var err error
+	var sBody subscriptionBody
+	var expirationTime int64
+	var userID uint64
+	var wpSub models.WebPushSubscription
+
+	if err = c.Bind(&sBody); err != nil {
+		return http.StatusBadRequest, gin.H{"status": "fail", "data": subscriptionBody{
+			Endpoint:       "endpoint is required, and need to be a string",
+			Keys:           "keys is required, and need to be a string",
+			ExpirationTime: "expirationTime is optional, if provide, need to be a string of timestamp",
+			UserID:         "user_id is optional, if provide, need to be a string",
+		}}, nil
+	}
+
+	// HashEndpoint is created by md5 hash.
+	// It is a unique key in the persistent database
+	// to avoid from creating the duplicate record
+	wpSub = models.WebPushSubscription{
+		Endpoint:     sBody.Endpoint,
+		HashEndpoint: fmt.Sprintf("%x", md5.Sum([]byte(sBody.Endpoint))),
+		Keys:         sBody.Keys,
+	}
+
+	if userID, err = strconv.ParseUint(sBody.UserID, 10, 0); err == nil {
+		wpSub.SetUserID(uint(userID))
+	}
+
+	if expirationTime, err = strconv.ParseInt(sBody.ExpirationTime, 10, 64); err == nil {
+		wpSub.SetExpirationTime(expirationTime)
+	}
+
+	if err = mc.Storage.CreateAWebPushSubscription(wpSub); err != nil {
+		switch appErr := err.(type) {
+		case models.AppError:
+			return 0, gin.H{}, models.NewAppError(errorWhere, "Fails to create a web push subscription", appErr.Error(), appErr.StatusCode)
+		default:
+			return http.StatusInternalServerError, gin.H{"status": "error", "message": "Unknown Error Type. Fails to create a web push subscription"}, nil
+		}
+	}
+
+	return http.StatusCreated, gin.H{"status": "success", "data": sBody}, nil
+}

--- a/membership_user.sql
+++ b/membership_user.sql
@@ -171,3 +171,26 @@ CREATE TABLE `users_bookmarks` (
   CONSTRAINT `fk_users_has_bookmarks_users1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+
+--
+-- Table structure for table `web_push_subscription`
+--
+
+DROP TABLE IF EXISTS `web_push_subscriptions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `web_push_subscriptions` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `endpoint` varchar(2048) NOT NULL,
+  `hash_endpoint` char(32) NOT NULL,
+  `keys` varchar(200) NOT NULL,
+  `expiration_time` timestamp NULL DEFAULT NULL,
+  `user_id` int(10) unsigned NULL DEFAULT NULL,
+  `created_at` timestamp DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `deleted_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uix_web_push_subscriptions_hash_endpoint` (`hash_endpoint`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;

--- a/models/subscription.go
+++ b/models/subscription.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"time"
+)
+
+// TODO add foreign key to bind web push subscription with user later
+// WebPushSubscription - a data model which is used by storage to communicate with persistent database
+type WebPushSubscription struct {
+	ID             uint       `json:"id"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+	DeletedAt      *time.Time `json:"deleted_at"`
+	Endpoint       string     `json:"endpoint"`
+	HashEndpoint   string     `gorm:"unique;" json:"hash_endpoint"`
+	Keys           string     `json:"-"`
+	ExpirationTime *time.Time `json:"expiration_time"`
+	UserID         *uint      `json:"user_id"`
+}
+
+// SetExpirationTime - set the pointer of expireTime into WebPushSubscription struct.
+// The reason why we set the pointer, not the value, into struct
+// is because we want to remain the NULL(nil) value if expireTime is not provided.
+func (wpSub *WebPushSubscription) SetExpirationTime(expireTime int64) {
+	_expireTime := time.Unix(expireTime, 0)
+	wpSub.ExpirationTime = &_expireTime
+}
+
+// SetUserID - set the pointer of userID into WebPushSubscription struct
+func (wpSub *WebPushSubscription) SetUserID(userID uint) {
+	wpSub.UserID = &userID
+}

--- a/storage/membership.go
+++ b/storage/membership.go
@@ -37,6 +37,10 @@ type MembershipStorage interface {
 	CreateABookmarkOfAUser(string, models.Bookmark) (models.Bookmark, error)
 	DeleteABookmarkOfAUser(string, string) error
 
+	/** Web Push Subscription methods **/
+	CreateAWebPushSubscription(models.WebPushSubscription) error
+	GetAWebPushSubscriptionByHashEndpoint(string) (models.WebPushSubscription, error)
+
 	/** Service methods **/
 	GetService(string) (models.Service, error)
 	CreateService(models.ServiceJSON) (models.Service, error)

--- a/storage/subscription.go
+++ b/storage/subscription.go
@@ -1,0 +1,27 @@
+package storage
+
+import (
+	"twreporter.org/go-api/models"
+)
+
+// CreateAWebPushSubscription - create a record in the persistent database,
+// return error if fails.
+func (g *GormStorage) CreateAWebPushSubscription(wpSub models.WebPushSubscription) error {
+	err := g.db.Create(&wpSub).Error
+	if err != nil {
+		return g.NewStorageError(err, "GormStorage.CreateAWebPushSubscription", "storage.subscription.error_to_create_a_subscription")
+	}
+	return nil
+}
+
+// GetAWebPushSubscriptionByHashEndpoint - read a record from persistent database according to its unique hash endpoint value
+func (g *GormStorage) GetAWebPushSubscriptionByHashEndpoint(hashEndpoint string) (models.WebPushSubscription, error) {
+	var wpSub models.WebPushSubscription
+	var err error
+
+	if err = g.db.Find(&wpSub, "hash_endpoint = ?", hashEndpoint).Error; err != nil {
+		return wpSub, g.NewStorageError(err, "GormStorage.GetAWebPushSubscriptionByHashEndpoint", "storage.subscription.error_to_get_a_web_push_subscription")
+	}
+
+	return wpSub, nil
+}

--- a/tests/controller_subscriptions_test.go
+++ b/tests/controller_subscriptions_test.go
@@ -1,0 +1,106 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"twreporter.org/go-api/models"
+)
+
+type wpSubResponse struct {
+	Status string                     `json:"status"`
+	Data   models.WebPushSubscription `json:"data"`
+}
+
+type WebPushSubscriptionPostBody struct {
+	Endpoint       string `json:"endpoint"`
+	Keys           string `json:"keys"`
+	ExpirationTime string `json:"expiration_time"`
+	UserID         string `json:"user_id"`
+}
+
+func TestIsWebPushSubscribed(t *testing.T) {
+	var resp *httptest.ResponseRecorder
+	var path string
+
+	path = fmt.Sprintf("/v1/web-push/subscriptions?endpoint=%v", Defaults.WebPushEndpoint)
+
+	/** START - Read a web push subscription successfully **/
+
+	resp = ServeHTTP("GET", path, "", "", "")
+	assert.Equal(t, resp.Code, 200)
+
+	body, _ := ioutil.ReadAll(resp.Result().Body)
+
+	res := wpSubResponse{}
+	json.Unmarshal(body, &res)
+
+	assert.Equal(t, Defaults.WebPushEndpoint, res.Data.Endpoint)
+
+	/** END - Read a web push subscription successfully **/
+
+	/** START - Fail to read a web push subscription **/
+
+	// Situation 1: Endpoint query param is not provided
+	path = "/v1/web-push/subscriptions?endpoint="
+	resp = ServeHTTP("GET", path, "", "", "")
+	assert.Equal(t, resp.Code, 404)
+
+	// Situation 2: Endpoint is provided, but database does not have it
+	path = "/v1/web-push/subscriptions?endpoint=http://web-push.subscriptions/endpoint-is-not-in-the-db"
+	resp = ServeHTTP("GET", path, "", "", "")
+	assert.Equal(t, resp.Code, 404)
+
+	/** END - Fail to read a web push subscription **/
+}
+
+func TestSubscribeWebPush(t *testing.T) {
+	var resp *httptest.ResponseRecorder
+	var path = "/v1/web-push/subscriptions"
+	var webPush WebPushSubscriptionPostBody
+	var webPushByteArray []byte
+
+	/** START - Add a web push subscription successfully **/
+	webPush = WebPushSubscriptionPostBody{
+		Endpoint:       "http://web-push.subscriptions/new.endpoint.to.subscribe",
+		Keys:           "{\"p256dh\":\"test-p256dh\",\"auth\":\"test-auth\"}",
+		ExpirationTime: "1526959900",
+		UserID:         "1",
+	}
+
+	webPushByteArray, _ = json.Marshal(webPush)
+	resp = ServeHTTP("POST", path, string(webPushByteArray), "application/json", "")
+	assert.Equal(t, resp.Code, 201)
+	/** END - Add a web push subscription successfully **/
+
+	/** START - Fail to add a web push subscription **/
+
+	// Situation 1: POST Body is not fully provided, lack of `keys`
+	webPush = WebPushSubscriptionPostBody{
+		Endpoint:       "http://web-push.subscriptions/another.endpoint.to.subscribe",
+		ExpirationTime: "1526959900",
+		UserID:         "1",
+	}
+
+	webPushByteArray, _ = json.Marshal(webPush)
+	resp = ServeHTTP("POST", path, string(webPushByteArray), "application/json", "")
+	assert.Equal(t, resp.Code, 400)
+
+	// Situation 2: Endpoint is already subscribed
+	webPush = WebPushSubscriptionPostBody{
+		Endpoint:       Defaults.WebPushEndpoint,
+		Keys:           "{\"p256dh\":\"test-p256dh\",\"auth\":\"test-auth\"}",
+		ExpirationTime: "1526959900",
+		UserID:         "1",
+	}
+
+	webPushByteArray, _ = json.Marshal(webPush)
+	resp = ServeHTTP("POST", path, string(webPushByteArray), "application/json", "")
+	assert.Equal(t, resp.Code, 409)
+
+	/** END - Fail to add a web push subscription **/
+}

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,26 @@ import (
 	"twreporter.org/go-api/constants"
 	"twreporter.org/go-api/models"
 )
+
+var Defaults = struct {
+	WebPushEndpoint string
+}{
+	WebPushEndpoint: "https://fcm.googleapis.com/fcm/send/f4Stnx6WC5s:APA91bFGo-JD8bDwezv1fx3RRyBVq6XxOkYIo8_7vCAJ3HFHLppKAV6GNmOIZLH0YeC2lM_Ifs9GkLK8Vi_8ASEYLBC1aU9nJy2rZSUfH7DE0AqIIbLrs93SdEdkwr5uL6skLPMjJsRQ",
+}
+
+// setDefaultWebPushSubscription - set up default records in web_push_subscriptions table
+func setDefaultWebPushSubscription() {
+	var path = "/v1/web-push/subscriptions"
+	var webPush = WebPushSubscriptionPostBody{
+		Endpoint:       Defaults.WebPushEndpoint,
+		Keys:           "{\"p256dh\":\"BDmY8OGe-LfW0ENPIADvmdZMo3GfX2J2yqURpsDOn5tT8lQV-VVHyhRUgzjnmx_RRoobwdLULdBr26oULtLML3w\",\"auth\":\"P_AJ9QSqcgM-KJi_GRN3fQ\"}",
+		ExpirationTime: "1526959900",
+		UserID:         "1",
+	}
+
+	webPushJSON, _ := json.Marshal(webPush)
+	ServeHTTP("POST", path, string(webPushJSON), "application/json", "")
+}
 
 func TestPing(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/v1/ping", nil)
@@ -39,6 +60,9 @@ func TestMain(m *testing.M) {
 	SetDefaultRecords()
 
 	SetupGinServer()
+
+	// add default records in web_push_subscriptions table
+	setDefaultWebPushSubscription()
 
 	retCode := m.Run()
 	os.Exit(retCode)

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -103,7 +103,7 @@ func RunMigration() {
 }
 
 func RunGormMigration() {
-	values := []interface{}{&models.User{}, &models.OAuthAccount{}, &models.ReporterAccount{}, &models.Bookmark{}, &models.Registration{}, &models.Service{}, &models.UsersBookmarks{}}
+	values := []interface{}{&models.User{}, &models.OAuthAccount{}, &models.ReporterAccount{}, &models.Bookmark{}, &models.Registration{}, &models.Service{}, &models.UsersBookmarks{}, &models.WebPushSubscription{}}
 	for _, value := range values {
 		DB.DropTable(value)
 	}


### PR DESCRIPTION
@babygoat  

There are two new endpoints for creating/reading web push subscription.
One is **POST** method for creating a web push subscription,
another is **GET** method for reading a web push subscription.

## New Endpoint `/web-push/subscriptions` 
### HTTP method: **POST**
### POST Body(either `application/JSON` or `x-www-form-urlencoded`): 
JSON example:
```
{
  "endpoint": "https://fcm.googleapis.com/fcm/send/f4Stnx6WC5s:APA91bFGo-JD8bDwezv1fx3RRyBVq6XxOkYIo8_7vCAJ3HFHLppKAV6GNmOIZLH0YeC2lM_Ifs9GkLK8Vi_8ASEYLBC1aU9nJy2rZSUfH7DE0AqIIbLrs93SdEdkwr5uL6skPMjJsMRT",
  "keys":"{\"p256dh\":\"BDmY8OGe-LfW0ENPIADvmdZMo3GfX2J2yqURpsDOn5tT8lQV-VVHyhRUgzjnmx_RRoobwdLULdBr26oULtLML3w\",\"auth\":\"P_AJ9QSqcgM-KJi_GRN3fQ\"}",
  "user_id": "1",
  "expirationTime": "1526457025"
}
```
### Response/ Status Code
**204** Created
**400** Bad request
**409** Duplicate record(depends on `endpoint` value)
**500** Internal server error

### HTTP method: **GET**
### Query Param: `endpoint`
Query example: `/v1/web-push/subscriptions?endpoint=https://fcm.googleapis.com/fcm/send/cmqyujQBXZU:APA91bHKpHph3rObZixXGpPHmX5dvd2FO5artSS86QeLK8VBaC91fcrJvqGfCe8n9YaDcamu6u07hx5i45sGUBs7hBRU39YIwduTNM3SIcr39frdl9KwlvVkeFiH8vqGPDo5JpSh92cn`
### Response/ Status Code
**200** Ok
**400** Bad request
**404** Record not found
**500** Internal server error

### TODO List
1) ~~Update README.md~~
2) ~~Functional test~~
3) Bind webpush subscription with user if needed in the future