### PR TITLE
Fix circle-ci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,12 +102,16 @@ jobs:
             fi
 
             echo "CLUSTER_NAME: ${CLUSTER_NAME}"
+            echo "CLUSTER_NAME=${CLUSTER_NAME}" > circle_ci_local_env
             gcloud --quiet container clusters get-credentials $CLUSTER_NAME
 
       - run:
           name: Install kubectl
           command: |
-            KUBECTL_VERSION="$(gcloud container clusters describe ${CLUSTER_NAME} | sed -n 's/.*version:[ ]*\(.*\)-\(.*\)/\1/p')"
+            source circle_ci_local_env
+            echo "CLUSTER_NAME: ${CLUSTER_NAME}"
+            KUBECTL_VERSION="$(gcloud container clusters describe ${CLUSTER_NAME} | sed -n 's/.*currentMasterVersion:[ ]*\(.*\)-\(.*\)/\1/p')"
+            echo "KUBECTL_VERSION=${KUBECTL_VERSION}"
             curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
             chmod +x ./kubectl
             sudo mv ./kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
This patch ports the circle-config fixes from twreporter-react repo
for following error.
* Missing CLUSTER_NAME environment variable in "kubectl install" step.
* Fetch the master node version of the cluster instead as there might
exist multiple versions within clusters.