### PR TITLE
Fix missing field in token draft record

### DIFF
--- a/controllers/donation.go
+++ b/controllers/donation.go
@@ -508,6 +508,7 @@ func buildTokenDraftRecord(req tapPayPrimeReq) models.PayByCardTokenDonation {
 	m.Details = req.Details
 	m.MerchantID = req.MerchantID
 	m.OrderNumber = req.OrderNumber
+	m.Amount = req.Amount
 
 	m.Status = statusPaying
 


### PR DESCRIPTION
This patch sets the missing field `amount` when creating the draft token
record.