### PR TITLE
update development environment setup. build the dev mysql env on the fly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ gin-bin*
 configs/config.json
 cloud_sql_proxy
 dump.rdb
+
+
+# Builds
+dev-env-setup/mysql/initdb.sql

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ help:
 		@echo "make test to run the functional test"
 
 env-up:
-		@docker-compose -f $(DOCKER_COMPOSE_FILE) up -d
+		@cp ./membership_user.sql $(DEV_ENV_SETUP_FOLDER)/mysql/initdb.sql
+		@docker-compose -f $(DOCKER_COMPOSE_FILE) up --build -d
 
 env-down: 
 		@docker-compose -f $(DOCKER_COMPOSE_FILE) down

--- a/configs/config.go
+++ b/configs/config.go
@@ -38,9 +38,9 @@ email:
         char_set: utf-8
 db:
     mysql:
-        name: gorm
-        user: gorm
-        password: gorm
+        name: test_membership
+        user: test_membership
+        password: test_membership
         address: 127.0.0.1
         port: '3306'
     mongo:

--- a/dev-env-setup/docker-compose.yml
+++ b/dev-env-setup/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     mysql:
-        image: thereporter/dev-mysql-go-api
+        build: mysql/
         ports:
             - '3306:3306'
     mongodb:

--- a/dev-env-setup/mysql/Dockerfile
+++ b/dev-env-setup/mysql/Dockerfile
@@ -1,0 +1,17 @@
+# Start from official MySQL image
+From mysql:5.7.21
+
+# Add go-api test user
+ENV MYSQL_ALLOW_EMPTY_PASSWORD=true \
+    MYSQL_DATABASE=gorm \
+    MYSQL_USER=gorm \
+    MYSQL_PASSWORD=gorm
+
+# Add scripts for database scheme and developer account initialization
+RUN mkdir -p /init
+
+ADD initdb.sql /init/
+ADD initdb.sh /docker-entrypoint-initdb.d/
+ADD mysql.cnf /etc/mysql/conf.d/
+
+EXPOSE 3306

--- a/dev-env-setup/mysql/initdb.sh
+++ b/dev-env-setup/mysql/initdb.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+mysql -u root -e "CREATE DATABASE IF NOT EXISTS test_membership"
+
+mysql -u root test_membership < /init/initdb.sql
+
+mysql -u root -e "CREATE USER 'test_membership'@'%' IDENTIFIED BY 'test_membership'"
+
+mysql -u root -e "GRANT ALL PRIVILEGES ON test_membership.* TO 'test_membership'@'%'"

--- a/dev-env-setup/mysql/mysql.cnf
+++ b/dev-env-setup/mysql/mysql.cnf
@@ -1,0 +1,16 @@
+# general client configuration
+[client]
+default-character-set=utf8mb4
+
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+
+# SET character_set_client = utf8mb4
+# SET character_set_results = utf8mb4
+# SET character_set_connection = utf8mb4
+init_connect='SET NAMES utf8mb4'
+
+# "mysql" client configuration
+[mysql]
+default-character-set=utf8mb4


### PR DESCRIPTION
@babygoat @YuCJ 

If we want to quickly set up a development environment,
we can easily run `make env-up` in cmd.
and `make env-down` to stop the development environment.