### PR TITLE
hot fix(bug). remove middlewares.jwt.ValidateIDToken

### DIFF
--- a/middlewares/jwt.go
+++ b/middlewares/jwt.go
@@ -79,22 +79,6 @@ func ValidateAuthentication() gin.HandlerFunc {
 	}
 }
 
-func ValidateIDToken() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		user := c.Request.Context().Value("user")
-		claims := user.(*jwt.Token).Claims.(utils.IDTokenJWTClaims)
-
-		if err := claims.Valid(); nil != err {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"status": "fail",
-				"data": gin.H{
-					"req.Headers.Authorization": err.Error(),
-				},
-			})
-		}
-	}
-}
-
 // SetEmailClaim get email value from jwt, and set it into gin.Context
 func SetEmailClaim() gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/routers/router.go
+++ b/routers/router.go
@@ -182,7 +182,7 @@ func SetupRouter(cf *controllers.ControllerFactory) *gin.Engine {
 	// =============================
 	v2AuthGroup.POST("/signin", middlewares.SetCacheControl("no-store"), ginResponseWrapper(mc.SignInV2))
 	v2AuthGroup.GET("/activate", middlewares.SetCacheControl("no-store"), mc.ActivateV2)
-	v2AuthGroup.POST("/token", middlewares.CheckJWT(), middlewares.ValidateIDToken(), middlewares.SetCacheControl("no-store"), mc.TokenDispatch)
+	v2AuthGroup.POST("/token", middlewares.CheckJWT(), middlewares.SetCacheControl("no-store"), mc.TokenDispatch)
 	v2AuthGroup.GET("/logout", mc.TokenInvalidate)
 	return engine
 }


### PR DESCRIPTION
Panic will arise when type assertion.

Since the following code didn't work,
`user.(*jwt.Token).Claims.(utils.IDTokenJWTClaims)`,
we may need to find another way to check IDTokenJWTClaims's validation.

However, if we change the code back to previous commit, like below,
`user.(*jwt.Token).Claims.(jwt.MapClaims)`,
it does the same thing(parse JWT and check its validation)
what `CheckJWT` already does.

Hence, remove ValidateIDToken function before we find another way
to check IDTokenJWTClaims's validation.

@babygoat 