### PR TITLE
Only development environment can return draft posts or topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Send thank-you donation email after success donation
 - Api documents for donation, mail, version 2 auth/oauth endpoints
 - `form` request body is not supported on donation and mail controllers anymore
+- Only development environment can return draft posts or topics
 
 ### Released 
 

--- a/storage/post.go
+++ b/storage/post.go
@@ -9,7 +9,7 @@ import (
 func (m *MongoStorage) _GetPosts(mq models.MongoQuery, limit int, offset int, sort string, embedded []string, isFull bool) ([]models.Post, int, error) {
 	var posts []models.Post
 
-	if globals.Conf.Environment == "production" {
+	if globals.Conf.Environment != "development" {
 		mq.State = "published"
 	}
 

--- a/storage/topic.go
+++ b/storage/topic.go
@@ -10,7 +10,7 @@ import (
 func (m *MongoStorage) _GetTopics(mq models.MongoQuery, limit int, offset int, sort string, embedded []string, isFull bool) ([]models.Topic, int, error) {
 	var topics []models.Topic
 
-	if globals.Conf.Environment == "production" {
+	if globals.Conf.Environment != "development" {
 		mq.State = "published"
 	}
 


### PR DESCRIPTION
### Problem description
Behavior: 
We can fetch draft pots/topics from staging-go-api.twreporter.org.

Reason:
In the latest configs, the environment could be `development`, `staging` or `production`.
However, the codes only prevent `production` environment from fetching draft topics/posts.
Hence, in the `staging` environment, we could fetch the drat ones.

### Change log
Only allow development environment to return draft posts/topics.