### PR TITLE
Update go vendor package version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: thereporter/circleci-go-api:latest
+      - image: thereporter/circleci-go-api:1.10-alpine3.8
       - image: circleci/mongo:3.2
       - image: circleci/mysql:5.7
         environment:

--- a/glide.lock
+++ b/glide.lock
@@ -1,19 +1,19 @@
 hash: 2f8b4f0d6800da4322d085afb7e417a82270b936b830ce7026c80bc75382de98
-updated: 2018-09-26T19:24:29.041010934+08:00
+updated: 2019-03-14T19:17:03.775958453+08:00
 imports:
 - name: cloud.google.com/go
-  version: 97efc2c9ffd9fe8ef47f7f3203dc60bbca547374
+  version: f52f9bc132541d2aa914f42100c36d10b1ef7e0c
   subpackages:
   - compute/metadata
 - name: github.com/algolia/algoliasearch-client-go
-  version: 68149ecd478242b4323aa535fe0fadca0d98912e
+  version: 1c0b06b9e47a0110de105eeb0aa2fdeda6e4a422
   subpackages:
   - algoliasearch
   - algoliasearch/call
 - name: github.com/auth0/go-jwt-middleware
   version: 5493cabe49f7bfa6e2ec444a09d334d90cd4e2bd
 - name: github.com/aws/aws-sdk-go
-  version: cbd7ed8b82dac1de35d67e576f0b3faf215e1ae9
+  version: b0b23985ea7533af9f94731b2c1030a1e46e6500
   subpackages:
   - aws
   - aws/awserr
@@ -24,6 +24,7 @@ imports:
   - aws/credentials
   - aws/credentials/ec2rolecreds
   - aws/credentials/endpointcreds
+  - aws/credentials/processcreds
   - aws/credentials/stscreds
   - aws/csm
   - aws/defaults
@@ -32,6 +33,7 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/ini
   - internal/sdkio
   - internal/sdkrand
   - internal/sdkuri
@@ -46,7 +48,7 @@ imports:
 - name: github.com/dgrijalva/jwt-go
   version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
 - name: github.com/fsnotify/fsnotify
-  version: ccc981bf80385c528a65fbfdd49bf2d8da22aa23
+  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: github.com/gin-contrib/cors
   version: 567de191692713543513692ecba9f6ca08cd660a
 - name: github.com/gin-contrib/sessions
@@ -61,10 +63,8 @@ imports:
   - binding
   - json
   - render
-- name: github.com/go-ini/ini
-  version: 3d73f4b845efdf9989fffd4b4e562727744a34ba
 - name: github.com/go-sql-driver/mysql
-  version: d523deb1b23d913de5bdada721a6071e71283618
+  version: 72cd26f257d44c1114970e19afddcd812016007e
 - name: github.com/golang/protobuf
   version: 2402d76f3d41f928c7902a765dfc872356dd3aad
   subpackages:
@@ -72,11 +72,11 @@ imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/securecookie
-  version: bb1ab76598893258e90f45d8a708a2505a95af2a
+  version: 51f47194a536d357035c4ad9304e2fa42dde262a
 - name: github.com/gorilla/sessions
   version: 03b6f63cc43ef9c7240a635a5e22b13180e822b8
 - name: github.com/hashicorp/hcl
-  version: 65a6292f0157eff210d03ed1bf6c59b190b8b906
+  version: 8cb6e5b959231cc1119e43259c4a608f9c51a241
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -92,7 +92,7 @@ imports:
 - name: github.com/jinzhu/copier
   version: 7e38e58719c33e0d44d585c4ab477a30f8cb82dd
 - name: github.com/jinzhu/gorm
-  version: 6ed508ec6a4ecb3531899a69cbc746ccf65a4166
+  version: 472c70caa40267cb89fd8facb07fe6454b578626
   subpackages:
   - dialects/mysql
 - name: github.com/jinzhu/inflection
@@ -100,7 +100,7 @@ imports:
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/json-iterator/go
-  version: 2433035e513208b0f7bd5b50d0aecd889b2c1ff8
+  version: 1624edc4454b8682399def8740d46db5e4362ba4
 - name: github.com/kidstuff/mongostore
   version: db2a8b4fac1f737c75e7fb84cb3fdb07dfc8fbc9
 - name: github.com/magiconair/properties
@@ -114,27 +114,25 @@ imports:
 - name: github.com/modern-go/reflect2
   version: 94122c33edd36123c84d5368cfb2b69df93a0ec8
 - name: github.com/pelletier/go-toml
-  version: 78b76feda6f35b2c5c1d283513f6419e59086729
+  version: c2dbbc24a97911339e01bda0b8cabdbd8f13b602
 - name: github.com/Sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/afero
-  version: d40851caa0d747393da1ffb28f7f9d8b4eeffebd
+  version: 787d034dfe70e44075ccc060d346146ef53270ad
   subpackages:
   - mem
 - name: github.com/spf13/cast
   version: 8965335b8c7107321228e3e3702cab9832751bac
 - name: github.com/spf13/jwalterweatherman
-  version: 4a4406e478ca629068e7768fc33f3f044173c0a6
+  version: 14d3d4c518341bea657dd8a226f5121c0ff8c9f2
 - name: github.com/spf13/pflag
-  version: 298182f68c66c05229eb03ac171abe6e309ee79a
+  version: d929dcbb10863323c436af3cf76cb16a6dfc9b29
 - name: github.com/spf13/viper
-  version: 8fb642006536c8d3760c99d4fa2389f5e2205631
+  version: 9e56dacc08fbbf8c9ee2dbc717553c758ce42bc9
 - name: github.com/stretchr/testify
-  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
+  version: ffdc059bfe9ce6a4e144ba849dbedead332c6053
   subpackages:
   - assert
-  - require
-  - suite
 - name: github.com/tidwall/gjson
   version: 0623bd8fbdbf97cc62b98d15108832851a658e59
 - name: github.com/tidwall/match
@@ -152,7 +150,6 @@ imports:
   version: d4c55e66d8c3a2f3382d264b08e3e3454a66355a
   subpackages:
   - context
-  - context/ctxhttp
   - http2
 - name: golang.org/x/oauth2
   version: ad516a297a9f2a74ecc244861b298c94bdd28b9d
@@ -167,7 +164,7 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: 905a57155faa8230500121607930ebb9dd8e139c
+  version: 6e3c4e7365ddcc329f090f96e4348398f6310088
   subpackages:
   - transform
   - unicode/norm

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
   subpackages:
   - assert
 - package: github.com/jinzhu/gorm
-  version: ^1.0.0
+  version: ^1.9.2
 - package: github.com/go-sql-driver/mysql
   version: ^1.3.0
 - package: github.com/jinzhu/configor


### PR DESCRIPTION
This patch updates the go vendor package to the lastest commit. Majorly
, the changes are to adopt the fix in gorm@1.9.2.