### PR TITLE
Fix incorrect schema during donation test

### DIFF
--- a/controllers/donation.go
+++ b/controllers/donation.go
@@ -176,6 +176,7 @@ type (
 
 	tapPayTransactionResp struct {
 		models.TappayResp
+		models.PayInfo
 		BankTransactionTime   bankTransactionTime `json:"bank_transaction_time"`
 		CardInfo              models.CardInfo     `json:"card_info"`
 		CardSecret            cardSecret          `json:"card_secret"`
@@ -891,13 +892,13 @@ func (resp tapPayTransactionResp) AppendRespOnTokenDonation(m *models.PayByCardT
 }
 
 func (resp tapPayTransactionResp) AppendLinePayOnPrimeDonation(m *models.PayByPrimeDonation, status string) {
-	m.TappayResp.PayInfo = resp.TappayResp.PayInfo
+	m.PayInfo = resp.PayInfo
 
-	if resp.TappayResp.PayInfo.Method.String == linePayMethodCreditCard {
-		m.CardInfo.LastFour = null.StringFrom(strings.Replace(resp.TappayResp.PayInfo.MaskedCreditCardNumber.String, "*", "", -1))
+	if resp.PayInfo.Method.String == linePayMethodCreditCard {
+		m.CardInfo.LastFour = null.StringFrom(strings.Replace(resp.PayInfo.MaskedCreditCardNumber.String, "*", "", -1))
 	}
-	m.TappayResp.BankResultMsg = resp.TappayResp.BankResultMsg
-	m.TappayResp.BankResultCode = resp.TappayResp.BankResultCode
+	m.BankResultMsg = resp.BankResultMsg
+	m.BankResultCode = resp.BankResultCode
 	m.Status = status
 }
 

--- a/models/donation.go
+++ b/models/donation.go
@@ -7,7 +7,6 @@ import (
 )
 
 type TappayResp struct {
-	PayInfo                  `json:"pay_info"`
 	Acquirer                 string      `gorm:"type:varchar(50);not null" json:"acquirer"`
 	AuthCode                 string      `gorm:"type:varchar(6);not null" json:"auth_code"`
 	BankResultCode           null.String `gorm:"type:varchar(50)" json:"bank_result_code"`
@@ -55,6 +54,7 @@ type PayByPrimeDonation struct {
 	CardInfo
 	Cardholder
 	TappayResp
+	PayInfo     `json:"pay_info"`
 	Amount      uint       `gorm:"not null" json:"amount"`
 	CreatedAt   time.Time  `json:"created_at"`
 	Currency    string     `gorm:"type:varchar(3);default:'TWD';not null" json:"currency"`

--- a/tests/controller_donations_test.go
+++ b/tests/controller_donations_test.go
@@ -70,16 +70,16 @@ type (
 	}
 
 	tapPayRequestBody struct {
-		RecTradeID        string         `json:"rec_trade_id"`
-		BankTransactionID string         `json:"bank_transaction_id"`
-		OrderNumber       string         `json:"order_number"`
-		Amount            uint           `json:"amount"`
-		Status            int            `json:"status"`
-		TransactionTime   int64          `json:"transaction_time_millis"`
-		PayInfo           models.PayInfo `json:"pay_info"`
-		Acquirer          string         `json:"acquirer"`
-		BankResultCode    string         `json:"bank_result_code"`
-		BankResultMsg     string         `json:"bank_result_msg"`
+		models.PayInfo
+		RecTradeID        string `json:"rec_trade_id"`
+		BankTransactionID string `json:"bank_transaction_id"`
+		OrderNumber       string `json:"order_number"`
+		Amount            uint   `json:"amount"`
+		Status            int    `json:"status"`
+		TransactionTime   int64  `json:"transaction_time_millis"`
+		Acquirer          string `json:"acquirer"`
+		BankResultCode    string `json:"bank_result_code"`
+		BankResultMsg     string `json:"bank_result_msg"`
 	}
 )
 
@@ -978,7 +978,7 @@ func TestLinePayNotify(t *testing.T) {
 				PayInfo: models.PayInfo{
 					Method:                 null.StringFrom("CREDIT_CARD"),
 					MaskedCreditCardNumber: null.StringFrom("************5566"),
-					Point: null.IntFrom(0),
+					Point:                  null.IntFrom(0),
 				},
 			},
 			resultCode: http.StatusUnprocessableEntity,
@@ -991,7 +991,7 @@ func TestLinePayNotify(t *testing.T) {
 				PayInfo: models.PayInfo{
 					Method:                 null.StringFrom("CREDIT_CARD"),
 					MaskedCreditCardNumber: null.StringFrom("************5566"),
-					Point: null.IntFrom(0),
+					Point:                  null.IntFrom(0),
 				},
 			},
 			resultCode: http.StatusUnprocessableEntity,
@@ -1004,7 +1004,7 @@ func TestLinePayNotify(t *testing.T) {
 				PayInfo: models.PayInfo{
 					Method:                 null.StringFrom("CREDIT_CARD"),
 					MaskedCreditCardNumber: null.StringFrom("************5566"),
-					Point: null.IntFrom(0),
+					Point:                  null.IntFrom(0),
 				},
 			},
 			resultCode: http.StatusUnprocessableEntity,
@@ -1022,7 +1022,7 @@ func TestLinePayNotify(t *testing.T) {
 				PayInfo: models.PayInfo{
 					Method:                 null.StringFrom("CREDIT_CARD"),
 					MaskedCreditCardNumber: null.StringFrom("************5566"),
-					Point: null.IntFrom(0),
+					Point:                  null.IntFrom(0),
 				},
 				Acquirer:       "Test Acquirer",
 				BankResultMsg:  newBankResultMsg,
@@ -1051,7 +1051,7 @@ func TestLinePayNotify(t *testing.T) {
 				PayInfo: models.PayInfo{
 					Method:                 null.StringFrom("BALANCE"),
 					MaskedCreditCardNumber: null.StringFrom("************5566"),
-					Point: null.IntFrom(0),
+					Point:                  null.IntFrom(0),
 				},
 				Acquirer:       "Test Acquirer",
 				BankResultMsg:  newBankResultMsg,
@@ -1090,9 +1090,9 @@ func TestLinePayNotify(t *testing.T) {
 			if c.resultCode == http.StatusNoContent {
 				m := models.PayByPrimeDonation{}
 				db.Where("order_number = ?", c.preRecord.OrderNumber).Find(&m)
-				assert.Equal(t, c.resultCompare.Method, m.TappayResp.PayInfo.Method.String)
+				assert.Equal(t, c.resultCompare.Method, m.PayInfo.Method.String)
 				assert.Equal(t, c.resultCompare.LastFour, m.CardInfo.LastFour.String)
-				assert.Equal(t, c.resultCompare.Point, m.TappayResp.PayInfo.Point.Int64)
+				assert.Equal(t, c.resultCompare.Point, m.PayInfo.Point.Int64)
 				assert.Equal(t, c.resultCompare.Status, m.Status)
 				assert.Equal(t, c.resultCompare.BankResultMsg, m.BankResultMsg.String)
 				assert.Equal(t, c.resultCompare.BankResultCode, m.BankResultCode.String)


### PR DESCRIPTION
This patch fixes the incorrect schemas of pay_by_card_token_donations.
It results from the incorrect placement of `PayInfo` model which should
be specifc fields within pay_by_prime_donations model.