### PR TITLE
Disable Docker Layer Caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,8 +112,7 @@ jobs:
 
             echo "CLUSTER_NAME: ${CLUSTER_NAME}"
             gcloud --quiet container clusters get-credentials $CLUSTER_NAME
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       
       - attach_workspace:
           at: /go/src/twreporter.org/go-api


### PR DESCRIPTION
This patch disables the docker layer caching as the CircleCI pricing
plan change with the no free plan DLC support.