### PR TITLE
chore: `pay_by_card_token_donations` table schema change

### DIFF
--- a/migrations/000007_delete-receipt_header-from-pay_by_card_token_donations.down.sql
+++ b/migrations/000007_delete-receipt_header-from-pay_by_card_token_donations.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pay_by_card_token_donations` ADD `receipt_header` varchar(128) DEFAULT NULL;

--- a/migrations/000007_delete-receipt_header-from-pay_by_card_token_donations.up.sql
+++ b/migrations/000007_delete-receipt_header-from-pay_by_card_token_donations.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pay_by_card_token_donations` DROP `receipt_header`;


### PR DESCRIPTION
This patch updates schema of table `pay_by_card_token_donations`
by removing `receipt_header` column.
Add corresponding
`000007_delete-receipt_header-from-pay_by_card_token_donations.down.sql`
and `000007_delete-receipt_header-from-pay_by_card_token_donations.up.sql`
for migration.