### PR TITLE
all: rename module to github host

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
         environment:
           GO111MODULE: "on"
 
-    working_directory: /go/src/twreporter.org/go-api
+    working_directory: /go/src/github.com/twreporter/go-api
 
     steps:
       - checkout
@@ -38,7 +38,7 @@ jobs:
           command: go run ./.circleci/scripts/read-changelog.go > .pkg-version
 
       - persist_to_workspace:
-          root: /go/src/twreporter.org/go-api
+          root: /go/src/github.com/twreporter/go-api
           paths:
             - ./*
 
@@ -56,7 +56,7 @@ jobs:
           MYSQL_PASSWORD: gorm
           MYSQL_ROOT_HOST: "%"
 
-    working_directory: /go/src/twreporter.org/go-api
+    working_directory: /go/src/github.com/twreporter/go-api
 
     steps:
       - attach_workspace:
@@ -87,13 +87,13 @@ jobs:
     docker:
       - image: google/cloud-sdk
 
-    working_directory: /go/src/twreporter.org/go-api
+    working_directory: /go/src/github.com/twreporter/go-api
 
     steps:
       - setup_remote_docker
 
       - attach_workspace:
-          at: /go/src/twreporter.org/go-api
+          at: /go/src/github.com/twreporter/go-api
 
       - run:
           name: Setup custom environment variables

--- a/.circleci/scripts/read-changelog.go
+++ b/.circleci/scripts/read-changelog.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	p, _ := build.Default.Import("twreporter.org/go-api", "", build.FindOnly)
+	p, _ := build.Default.Import("github.com/twreporter/go-api", "", build.FindOnly)
 
 	fname := filepath.Join(p.Dir, "CHANGELOG.md")
 	file, err := os.Open(fname)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY go.sum .
 RUN go mod download
 RUN go mod verify
 
-WORKDIR /go/src/twreporter.org/go-api
+WORKDIR /go/src/github.com/twreporter/go-api
 
 # Copy the local package files to the container's workspace.
 COPY . .

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Please make sure that you install [Glide
   package manager](https://github.com/Masterminds/glide) in the environment. (Switch to [go module](https://github.com/golang/go/wiki/Modules) after v5.0.0)
 
 ```
-cd $GOPATH/src/twreporter.org/go-api
+cd $GOPATH/src/github.com/twreporter/go-api
 glide install                           # Install packages and dependencies
 
 // use Makefile

--- a/configs/config.go
+++ b/configs/config.go
@@ -306,7 +306,7 @@ func LoadConf(confPath string) (ConfYaml, error) {
 			return conf, errors.WithStack(err)
 		}
 	} else {
-		viper.AddConfigPath("$GOPATH/src/twreporter.org/go-api/configs/")
+		viper.AddConfigPath("$GOPATH/src/github.com/twreporter/go-api/configs/")
 		viper.AddConfigPath("./configs/")
 		viper.SetConfigName("config")
 

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"twreporter.org/go-api/configs"
+	"github.com/twreporter/go-api/configs"
 )
 
 func TestLoadConf(t *testing.T) {

--- a/controllers/account.go
+++ b/controllers/account.go
@@ -12,10 +12,10 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
-	"twreporter.org/go-api/storage"
-	"twreporter.org/go-api/utils"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
+	"github.com/twreporter/go-api/storage"
+	"github.com/twreporter/go-api/utils"
 )
 
 const (

--- a/controllers/author.go
+++ b/controllers/author.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 // GetAuthors receive HTTP GET method request, and return the authors.

--- a/controllers/bookmark.go
+++ b/controllers/bookmark.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 // GetBookmarksOfAUser given userID this func will list all the bookmarks belongs to the user

--- a/controllers/controller-factory.go
+++ b/controllers/controller-factory.go
@@ -7,10 +7,10 @@ import (
 	"github.com/jinzhu/gorm"
 	"go.mongodb.org/mongo-driver/mongo"
 	"gopkg.in/mgo.v2"
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/services"
-	"twreporter.org/go-api/storage"
-	"twreporter.org/go-api/utils"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/services"
+	"github.com/twreporter/go-api/storage"
+	"github.com/twreporter/go-api/utils"
 )
 
 // ControllerFactory generates controlloers by given persistent storage connection

--- a/controllers/donation.go
+++ b/controllers/donation.go
@@ -25,9 +25,9 @@ import (
 	"gopkg.in/go-playground/validator.v8"
 	"gopkg.in/guregu/null.v3"
 
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
-	"twreporter.org/go-api/storage"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
+	"github.com/twreporter/go-api/storage"
 )
 
 const (

--- a/controllers/errors.go
+++ b/controllers/errors.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 
-	"twreporter.org/go-api/storage"
+	"github.com/twreporter/go-api/storage"
 )
 
 func toResponse(err error) (int, gin.H, error) {

--- a/controllers/index_page.go
+++ b/controllers/index_page.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"gopkg.in/mgo.v2/bson"
-	"twreporter.org/go-api/configs"
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/configs"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/controllers/mail.go
+++ b/controllers/mail.go
@@ -14,8 +14,8 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/guregu/null.v3"
 
-	"twreporter.org/go-api/services"
-	"twreporter.org/go-api/utils"
+	"github.com/twreporter/go-api/services"
+	"github.com/twreporter/go-api/utils"
 )
 
 type activationReqBody struct {

--- a/controllers/membership.go
+++ b/controllers/membership.go
@@ -1,7 +1,7 @@
 package controllers
 
 import (
-	"twreporter.org/go-api/storage"
+	"github.com/twreporter/go-api/storage"
 )
 
 // NewMembershipController ...

--- a/controllers/news.go
+++ b/controllers/news.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"twreporter.org/go-api/models"
-	"twreporter.org/go-api/storage"
+	"github.com/twreporter/go-api/models"
+	"github.com/twreporter/go-api/storage"
 )
 
 // NewsController has methods to handle requests which wants posts, topics ... etc news resource.

--- a/controllers/news_v2.go
+++ b/controllers/news_v2.go
@@ -8,8 +8,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/internal/news"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/internal/news"
 )
 
 type newsV2Storage interface {

--- a/controllers/oauth.go
+++ b/controllers/oauth.go
@@ -18,10 +18,10 @@ import (
 	"golang.org/x/oauth2/google"
 	"gopkg.in/guregu/null.v3"
 
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
-	"twreporter.org/go-api/storage"
-	"twreporter.org/go-api/utils"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
+	"github.com/twreporter/go-api/storage"
+	"github.com/twreporter/go-api/utils"
 )
 
 const defaultDestination = "https://www.twreporter.org/"

--- a/controllers/post.go
+++ b/controllers/post.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 // GetPosts receive HTTP GET method request, and return the posts.

--- a/controllers/search.go
+++ b/controllers/search.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	f "github.com/twreporter/logformatter"
 
-	"twreporter.org/go-api/globals"
+	"github.com/twreporter/go-api/globals"
 )
 
 // search - search records from algolia webservice

--- a/controllers/subscription.go
+++ b/controllers/subscription.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 // IsWebPushSubscribed - which handles the HTTP Get request,

--- a/controllers/topic.go
+++ b/controllers/topic.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 // GetTopics receive HTTP GET method request, and return the topics.

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -1,7 +1,7 @@
 package globals
 
 import (
-	"twreporter.org/go-api/configs"
+	"github.com/twreporter/go-api/configs"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module twreporter.org/go-api
+module github.com/twreporter/go-api
 
 go 1.12
 
@@ -39,7 +39,6 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.4.0
-	github.com/twreporter/go-api v4.0.0+incompatible
 	github.com/twreporter/logformatter v0.0.0-20200211094126-60fe42618206
 	go.mongodb.org/mongo-driver v1.1.0
 	golang.org/x/crypto v0.0.0-20200210222208-86ce3cb69678

--- a/internal/news/mongo.go
+++ b/internal/news/mongo.go
@@ -7,8 +7,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"gopkg.in/guregu/null.v3"
-	"twreporter.org/go-api/internal/mongo"
-	"twreporter.org/go-api/internal/query"
+	"github.com/twreporter/go-api/internal/mongo"
+	"github.com/twreporter/go-api/internal/query"
 )
 
 // tagMongo is used to map the query field to the corresponded field in real mongo document

--- a/internal/news/query.go
+++ b/internal/news/query.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"gopkg.in/guregu/null.v3"
-	"twreporter.org/go-api/internal/query"
+	"github.com/twreporter/go-api/internal/query"
 )
 
 type Query struct {

--- a/internal/news/query_test.go
+++ b/internal/news/query_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"gopkg.in/guregu/null.v3"
-	"twreporter.org/go-api/internal/query"
+	"github.com/twreporter/go-api/internal/query"
 )
 
 func TestParseSinglePostQuery(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -13,13 +13,13 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 
-	"twreporter.org/go-api/configs"
-	"twreporter.org/go-api/controllers"
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/internal/mongo"
-	"twreporter.org/go-api/routers"
-	"twreporter.org/go-api/services"
-	"twreporter.org/go-api/utils"
+	"github.com/twreporter/go-api/configs"
+	"github.com/twreporter/go-api/controllers"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/internal/mongo"
+	"github.com/twreporter/go-api/routers"
+	"github.com/twreporter/go-api/services"
+	"github.com/twreporter/go-api/utils"
 )
 
 func main() {

--- a/middlewares/jwt.go
+++ b/middlewares/jwt.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/utils"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/utils"
 
 	"github.com/auth0/go-jwt-middleware"
 	"github.com/dgrijalva/jwt-go"

--- a/middlewares/mail-service.go
+++ b/middlewares/mail-service.go
@@ -6,7 +6,7 @@ import (
 	"github.com/auth0/go-jwt-middleware"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gin-gonic/gin"
-	"twreporter.org/go-api/globals"
+	"github.com/twreporter/go-api/globals"
 )
 
 const jwtUserPropertyForMailService = "mail-service-jwt"

--- a/routers/router.go
+++ b/routers/router.go
@@ -10,9 +10,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	f "github.com/twreporter/logformatter"
 
-	"twreporter.org/go-api/controllers"
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/middlewares"
+	"github.com/twreporter/go-api/controllers"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/middlewares"
 )
 
 const (

--- a/services/mail.go
+++ b/services/mail.go
@@ -14,8 +14,8 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"twreporter.org/go-api/configs"
-	"twreporter.org/go-api/globals"
+	"github.com/twreporter/go-api/configs"
+	"github.com/twreporter/go-api/globals"
 )
 
 // MailService defines an interface to be implemented

--- a/storage/asset.go
+++ b/storage/asset.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/mgo.v2/bson"
 
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 // _StringToPscalCase - change WORD to pscal-case

--- a/storage/author.go
+++ b/storage/author.go
@@ -7,8 +7,8 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/mgo.v2/bson"
 
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
 )
 
 // GetFullAuthors finds the authors according to mongo aggregation pipeline stages

--- a/storage/bookmark.go
+++ b/storage/bookmark.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 var (

--- a/storage/donation.go
+++ b/storage/donation.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 // CreateAPeriodicDonation creates the draft record along with the first draft tap pay transaction

--- a/storage/membership.go
+++ b/storage/membership.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/guregu/null.v3"
 
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 // MembershipStorage defines the methods we need to implement,

--- a/storage/news.go
+++ b/storage/news.go
@@ -7,8 +7,8 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
 )
 
 // NewsStorage defines the methods we need to implement,

--- a/storage/news_v2.go
+++ b/storage/news_v2.go
@@ -6,8 +6,8 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/internal/news"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/internal/news"
 )
 
 type fetchResult struct {

--- a/storage/post.go
+++ b/storage/post.go
@@ -1,8 +1,8 @@
 package storage
 
 import (
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
 )
 
 // _GetPosts finds the posts according to query string and also get the embedded assets

--- a/storage/service.go
+++ b/storage/service.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"github.com/pkg/errors"
 
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 // GetService ...

--- a/storage/subscription.go
+++ b/storage/subscription.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 // CreateAWebPushSubscription - create a record in the persistent database,

--- a/storage/topic.go
+++ b/storage/topic.go
@@ -1,8 +1,8 @@
 package storage
 
 import (
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
 )
 
 // _GetTopics finds the topics according to query string and also get the embedded assets

--- a/storage/user.go
+++ b/storage/user.go
@@ -8,8 +8,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/guregu/null.v3"
 
-	"twreporter.org/go-api/configs/constants"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/configs/constants"
+	"github.com/twreporter/go-api/models"
 )
 
 // GetUserByID gets the user by its ID

--- a/tests/controller_account_test.go
+++ b/tests/controller_account_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"twreporter.org/go-api/models"
-	"twreporter.org/go-api/storage"
+	"github.com/twreporter/go-api/models"
+	"github.com/twreporter/go-api/storage"
 )
 
 func TestSignIn(t *testing.T) {

--- a/tests/controller_bookmark_test.go
+++ b/tests/controller_bookmark_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/guregu/null.v3"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 type meta struct {

--- a/tests/controller_donations_test.go
+++ b/tests/controller_donations_test.go
@@ -12,8 +12,8 @@ import (
 	"gopkg.in/guregu/null.v3"
 
 	"github.com/stretchr/testify/assert"
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
 )
 
 type (

--- a/tests/controller_index_page_test.go
+++ b/tests/controller_index_page_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"twreporter.org/go-api/globals"
+	"github.com/twreporter/go-api/globals"
 )
 
 type indexPageResponse struct {

--- a/tests/controller_mail_test.go
+++ b/tests/controller_mail_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/utils"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/utils"
 )
 
 func TestSendActivation(t *testing.T) {

--- a/tests/controller_post_test.go
+++ b/tests/controller_post_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"twreporter.org/go-api/configs"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/configs"
+	"github.com/twreporter/go-api/models"
 )
 
 /*

--- a/tests/controller_subscriptions_test.go
+++ b/tests/controller_subscriptions_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 type wpSubResponse struct {

--- a/tests/controller_topic_test.go
+++ b/tests/controller_topic_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 /*

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -17,13 +17,13 @@ import (
 	mongodriver "go.mongodb.org/mongo-driver/mongo"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"twreporter.org/go-api/configs"
-	"twreporter.org/go-api/controllers"
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
-	"twreporter.org/go-api/routers"
-	"twreporter.org/go-api/storage"
-	"twreporter.org/go-api/utils"
+	"github.com/twreporter/go-api/configs"
+	"github.com/twreporter/go-api/controllers"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
+	"github.com/twreporter/go-api/routers"
+	"github.com/twreporter/go-api/storage"
+	"github.com/twreporter/go-api/utils"
 )
 
 var Globs globalVariables

--- a/tests/pre_test_environment_setup.go
+++ b/tests/pre_test_environment_setup.go
@@ -11,11 +11,11 @@ import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/internal/mongo"
-	"twreporter.org/go-api/models"
-	"twreporter.org/go-api/storage"
-	"twreporter.org/go-api/utils"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/internal/mongo"
+	"github.com/twreporter/go-api/models"
+	"github.com/twreporter/go-api/storage"
+	"github.com/twreporter/go-api/utils"
 )
 
 const (

--- a/tests/structs.go
+++ b/tests/structs.go
@@ -5,7 +5,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/models"
 )
 
 type defaultVariables struct {

--- a/utils/db.go
+++ b/utils/db.go
@@ -19,8 +19,8 @@ import (
 	"gopkg.in/matryer/try.v1"
 	"gopkg.in/mgo.v2"
 
-	"twreporter.org/go-api/globals"
-	"twreporter.org/go-api/models"
+	"github.com/twreporter/go-api/globals"
+	"github.com/twreporter/go-api/models"
 )
 
 // InitDB initiates the MySQL database connection

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"gopkg.in/guregu/null.v3"
 
-	"twreporter.org/go-api/configs/constants"
+	"github.com/twreporter/go-api/configs/constants"
 )
 
 // GetGender format the gender string

--- a/utils/token.go
+++ b/utils/token.go
@@ -6,7 +6,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 
-	"twreporter.org/go-api/globals"
+	"github.com/twreporter/go-api/globals"
 )
 
 type AuthTokenType int

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/scrypt"
 
-	"twreporter.org/go-api/globals"
+	"github.com/twreporter/go-api/globals"
 )
 
 // GenerateRandomBytes returns securely generated random bytes.
@@ -51,7 +51,7 @@ func GetProjectRoot() string {
 
 	// use the reflect package to retrieve current package path
 	// [go module name]/[package name]
-	// i.e. twreporter.org/go-api/utils
+	// i.e. github.com/twreporter/go-api/utils
 	pkg := reflect.TypeOf(emptyStruct{}).PkgPath()
 	pkgWithoutModPrefix := string([]byte(pkg)[strings.LastIndex(pkg, "/")+1:])
 


### PR DESCRIPTION
This patch renames the module to be github.com/twreporter/go-api as we
do not host our package directly.