### PR TITLE
chore: workaround configMapGenerator issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,18 +162,8 @@ jobs:
       - run:
           name: Install kustomize binaries
           command: |
-            opsys=linux
-
-            curl -s "https://api.github.com/repos/kubernetes-sigs/kustomize/releases" |\
-            grep browser_download |\
-            grep $opsys |\
-            cut -d '"' -f 4 |\
-            grep /kustomize/v |\
-            sort | tail -n 1 |\
-            xargs curl -O -L
-            tar xzf ./kustomize_v*_${opsys}_amd64.tar.gz -C /usr/bin
-            kustomize version
-
+            curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash -s 3.8.9
+            mv ./kustomize /usr/local/bin/
       - run:
           name: Prepare for kubernetes config build
           command: |


### PR DESCRIPTION
This patch workarounds the configMapGenerator issue which does not
quote the numeric value properly during merge operation.