### PR TITLE
api/donation: log donor info if the update occurs error

### DIFF
--- a/controllers/donation.go
+++ b/controllers/donation.go
@@ -713,6 +713,7 @@ func (mc *MembershipController) PatchADonationOfAUser(c *gin.Context, donationTy
 	}
 
 	if failData, valid = bindRequestJSONBody(c, &reqBody); valid == false {
+		log.WithField("payload", reqBody).Infof("cannot patch the personal info of the donor, %v", failData)
 		return http.StatusBadRequest, gin.H{"status": "fail", "data": failData}, nil
 	}
 


### PR DESCRIPTION
This patch logs the information of the donor which cannot be parsed
correctly and the detail can be utilized to provide instructions to the
donors.