### PR TITLE
fix: add pubsub credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,9 @@ jobs:
             # aws config
             echo ${AWS_CREDENTIALS} | base64 -i --decode > ./aws_credentials
 
+            # pubsub config
+            echo ${PUBSUB_CREDENTIALS} | base64 -i --decode > ./pubsub_credentials
+
             docker build -t gcr.io/coastal-run-106202/${APP}:$PKG_VER .
             gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://gcr.io
             docker push gcr.io/coastal-run-106202/${APP}:$PKG_VER

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,11 +59,13 @@ ARG server_user
 WORKDIR /home/${server_user}
 
 COPY ./aws_credentials /home/${server_user}/.aws/credentials 
+COPY ./pubsub_credentials /home/${server_user}/pubsub_credentials
 COPY ./entrypoint.sh /home/${server_user}/entrypoint.sh
 COPY ./migrations /home/${server_user}/migrations/
 COPY ./template /home/${server_user}/template/
 RUN chmod +x entrypoint.sh
 
+ENV GOOGLE_APPLICATION_CREDENTIALS /home/${server_user}/pubsub_credentials
 ENV MIGRATION_DIR /home/${server_user}/migrations/
 
 # Specify the user for running go-api


### PR DESCRIPTION
This patch add pubsub credentials to go-api image
- var `PUBSUB_CREDENTIALS` is defined in circleci env