### PR TITLE
api/doc: fix typo for `auto_tax_deduction`

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -123,7 +123,7 @@ It reprensents one periodic donation record identified by the order number(:orde
 <p>is_anonymous</p>
 </li>
 <li>
-<p>auto_tax_dedution</p>
+<p>auto_tax_deduction</p>
 </li>
 <li>
 <p>receipt</p>
@@ -197,7 +197,7 @@ It reprensents one periodic donation record identified by the order number(:orde
       "<span class="hljs-attribute">address_detail</span>": <span class="hljs-value"><span class="hljs-string">"南京東路一段300巷300號6樓"</span></span>,
       "<span class="hljs-attribute">address_zip_code</span>": <span class="hljs-value"><span class="hljs-string">"104"</span>
     </span>}</span>,
-    "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
+    "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
   </span>}
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -326,7 +326,7 @@ It reprensents one periodic donation record identified by the order number(:orde
             </span>}
           </span>}
         </span>}</span>,
-        "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
         </span>}
       </span>}</span>,
@@ -401,7 +401,7 @@ It reprensents one periodic donation record identified by the order number(:orde
     "<span class="hljs-attribute">address_detail</span>": <span class="hljs-value"><span class="hljs-string">"南京東路一段300巷300號6樓"</span></span>,
     "<span class="hljs-attribute">address_zip_code</span>": <span class="hljs-value"><span class="hljs-string">"104"</span>
   </span>}</span>,
-  "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
+  "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -503,7 +503,7 @@ It reprensents one periodic donation record identified by the order number(:orde
         </span>}
       </span>}
     </span>}</span>,
-    "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
     </span>}
   </span>}</span>,
@@ -546,7 +546,7 @@ It reprensents one periodic donation record identified by the order number(:orde
             "<span class="hljs-attribute">address_detail</span>": <span class="hljs-value"><span class="hljs-string">"address_detail(string) is optional"</span></span>,
             "<span class="hljs-attribute">address_zip_code</span>": <span class="hljs-value"><span class="hljs-string">"address_zip_code(string) is optional"</span></span>,
         }</span>,
-        "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value"><span class="hljs-string">"auto_tax_dedution(bool) is optional"</span></span>,
+        "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value"><span class="hljs-string">"auto_tax_deduction(bool) is optional"</span></span>,
     }
 </span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>401</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"fail"</span></span>,
@@ -662,7 +662,7 @@ It reprensents one periodic donation record identified by the order number(:orde
       "<span class="hljs-attribute">address_detail</span>": <span class="hljs-value"><span class="hljs-string">"南京東路一段300巷300號6樓"</span></span>,
       "<span class="hljs-attribute">address_zip_code</span>": <span class="hljs-value"><span class="hljs-string">"104"</span>
     </span>}</span>,
-    "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
+    "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
   </span>}
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -791,7 +791,7 @@ It reprensents one periodic donation record identified by the order number(:orde
             </span>}
           </span>}
         </span>}</span>,
-        "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
         </span>}
       </span>}</span>,
@@ -988,7 +988,7 @@ It represents one prime donation record identified by the order number (order).<
 <p>receipt.address_zip_code</p>
 </li>
 <li>
-<p>auto_tax_dedution</p>
+<p>auto_tax_deduction</p>
 </li>
 </ul>
 <p>The states <em>id</em> and <em>order_number</em> are assigned by the TWReporter Go API at the moment of creation.</p>
@@ -1031,7 +1031,7 @@ It represents one prime donation record identified by the order number (order).<
     "<span class="hljs-attribute">address_detail</span>": <span class="hljs-value"><span class="hljs-string">"南京東路一段300巷300號6樓"</span></span>,
     "<span class="hljs-attribute">address_zip_code</span>": <span class="hljs-value"><span class="hljs-string">"104"</span>
   </span>}</span>,
-  "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
+  "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
   "<span class="hljs-attribute">properties</span>": <span class="hljs-value">{
@@ -1147,7 +1147,7 @@ It represents one prime donation record identified by the order number (order).<
         </span>}
       </span>}
     </span>}</span>,
-    "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
     </span>}
   </span>}</span>,
@@ -1258,7 +1258,7 @@ It represents one prime donation record identified by the order number (order).<
     "<span class="hljs-attribute">address_detail</span>": <span class="hljs-value"><span class="hljs-string">"南京東路一段300巷300號6樓"</span></span>,
     "<span class="hljs-attribute">address_zip_code</span>": <span class="hljs-value"><span class="hljs-string">"104"</span>
   </span>}</span>,
-  "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
+  "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">$schema</span>": <span class="hljs-value"><span class="hljs-string">"http://json-schema.org/draft-04/schema#"</span></span>,
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -1357,7 +1357,7 @@ It represents one prime donation record identified by the order number (order).<
         </span>}
       </span>}
     </span>}</span>,
-    "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value">{
+    "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value">{
       "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
     </span>}
   </span>}</span>,
@@ -1399,7 +1399,7 @@ It represents one prime donation record identified by the order number (order).<
             "<span class="hljs-attribute">address_detail</span>": <span class="hljs-value"><span class="hljs-string">"address_detail(string) is optional"</span></span>,
             "<span class="hljs-attribute">address_zip_code</span>": <span class="hljs-value"><span class="hljs-string">"address_zip_code(string) is optional"</span></span>,
         }</span>,
-        "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value"><span class="hljs-string">"auto_tax_dedution(bool) is optional"</span></span>,
+        "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value"><span class="hljs-string">"auto_tax_deduction(bool) is optional"</span></span>,
     }
 </span>}</code></pre><div style="height: 1px;"></div></div></div><div class="title"><strong>Response&nbsp;&nbsp;<code>401</code></strong><div class="collapse-button"><span class="close">Hide</span><span class="open">Show</span></div></div><div class="collapse-content"><div class="inner"><h5>Headers</h5><pre><code><span class="hljs-attribute">Content-Type</span>: <span class="hljs-string">application/json</span></code></pre><div style="height: 1px;"></div><h5>Body</h5><pre><code>{
   "<span class="hljs-attribute">status</span>": <span class="hljs-value"><span class="hljs-string">"fail"</span></span>,
@@ -1595,7 +1595,7 @@ Only the linepay is required to do this verfication</p>
       "<span class="hljs-attribute">address_detail</span>": <span class="hljs-value"><span class="hljs-string">"南京東路一段300巷300號6樓"</span></span>,
       "<span class="hljs-attribute">address_zip_code</span>": <span class="hljs-value"><span class="hljs-string">"104"</span>
     </span>}</span>,
-    "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
+    "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value"><span class="hljs-string">"true"</span>
   </span>}
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
   "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"object"</span></span>,
@@ -1718,7 +1718,7 @@ Only the linepay is required to do this verfication</p>
             </span>}
           </span>}
         </span>}</span>,
-        "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
         </span>}
       </span>}</span>,
@@ -1942,7 +1942,7 @@ Only the linepay is required to do this verfication</p>
       "<span class="hljs-attribute">address_detail</span>": <span class="hljs-value"><span class="hljs-string">"南京東路一段300巷300號6樓"</span></span>,
       "<span class="hljs-attribute">address_zip_code</span>": <span class="hljs-value"><span class="hljs-string">"104"</span>
     </span>}</span>,
-    "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value"><span class="hljs-string">"true"</span></span>,
+    "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value"><span class="hljs-string">"true"</span></span>,
     "<span class="hljs-attribute">payment_url</span>": <span class="hljs-value"><span class="hljs-string">"https://sandbox-redirect.tappaysdk.com/redirect/906ec8348e5e893e098e56f1c061ae178fc80d193649305e83ca8788054e839d"</span>
   </span>}
 </span>}</code></pre><div style="height: 1px;"></div><h5>Schema</h5><pre><code>{
@@ -2066,7 +2066,7 @@ Only the linepay is required to do this verfication</p>
             </span>}
           </span>}
         </span>}</span>,
-        "<span class="hljs-attribute">auto_tax_dedution</span>": <span class="hljs-value">{
+        "<span class="hljs-attribute">auto_tax_deduction</span>": <span class="hljs-value">{
           "<span class="hljs-attribute">type</span>": <span class="hljs-value"><span class="hljs-string">"string"</span>
         </span>}</span>,
         "<span class="hljs-attribute">payment_url</span>": <span class="hljs-value">{
@@ -16110,7 +16110,7 @@ The email contains the following attributes</p>
     <span class="hljs-string">"status"</span>,
     <span class="hljs-string">"message"</span>
   ]
-</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 28 Jan 2022</p><script>/* eslint-env browser */
+</span>}</code></pre><div style="height: 1px;"></div></div></div></div></div></section></div></div></div><p style="text-align: center;" class="text-muted">Generated by&nbsp;<a href="https://github.com/danielgtaylor/aglio" class="aglio">aglio</a>&nbsp;on 24 Mar 2022</p><script>/* eslint-env browser */
 /* eslint quotes: [2, "single"] */
 'use strict';
 

--- a/doc/periodic-donation.apib
+++ b/doc/periodic-donation.apib
@@ -46,7 +46,7 @@ The Periodic Donation resource has the following attributes;
 - to_feedback
 - max_paid_times
 - is_anonymous
-- auto_tax_dedution
+- auto_tax_deduction
 - receipt 
 - receipt.header
 - receipt.security_id
@@ -163,7 +163,7 @@ The states *id* and *order_number* are assigned by the TWReporter Go API at the 
             + address_city: 中山區
             + address_detail: 南京東路一段300巷300號6樓
             + address_zip_code: 104
-        + auto_tax_dedution: true
+        + auto_tax_deduction: true
 
 + Response 204
 
@@ -207,7 +207,7 @@ The states *id* and *order_number* are assigned by the TWReporter Go API at the 
                         "address_detail": "address_detail(string) is optional",
                         "address_zip_code": "address_zip_code(string) is optional",
                     },
-                    "auto_tax_dedution": "auto_tax_dedution(bool) is optional",
+                    "auto_tax_deduction": "auto_tax_deduction(bool) is optional",
                 }
             }
 
@@ -363,7 +363,7 @@ The states *id* and *order_number* are assigned by the TWReporter Go API at the 
     + address_city: 中山區 (optional)
     + address_detail: 南京東路一段300巷300號6樓 (optional)
     + address_zip_code: 104 (optional)
-+ auto_tax_dedution: true (optional)
++ auto_tax_deduction: true (optional)
 
 ### PeriodicDonationResponse
 + status: success (required)

--- a/doc/prime-donation.apib
+++ b/doc/prime-donation.apib
@@ -54,7 +54,7 @@ The Prime Donation resource has the following attributes:
 - receipt.address_city
 - receipt.address_detail
 - receipt.address_zip_code
-- auto_tax_dedution
+- auto_tax_deduction
 
 The states *id* and *order_number* are assigned by the TWReporter Go API at the moment of creation.
 
@@ -139,7 +139,7 @@ The states *id* and *order_number* are assigned by the TWReporter Go API at the 
             + address_city: 中山區 
             + address_detail: 南京東路一段300巷300號6樓 
             + address_zip_code: 104 
-        + auto_tax_dedution: true
+        + auto_tax_deduction: true
 
 + Response 204
 
@@ -182,7 +182,7 @@ The states *id* and *order_number* are assigned by the TWReporter Go API at the 
                         "address_detail": "address_detail(string) is optional",
                         "address_zip_code": "address_zip_code(string) is optional",
                     },
-                    "auto_tax_dedution": "auto_tax_dedution(bool) is optional",
+                    "auto_tax_deduction": "auto_tax_deduction(bool) is optional",
                 }
             }
 
@@ -392,7 +392,7 @@ Endpoint for tappay server to notify line pay transaction result
     + address_city: 中山區 (optional)
     + address_detail: 南京東路一段300巷300號6樓 (optional)
     + address_zip_code: 104 (optional)
-+ auto_tax_dedution: true (optional)
++ auto_tax_deduction: true (optional)
 
 ### PrimeDonationByCreditCardResponse
 + status: success (required)


### PR DESCRIPTION
This patch fixes typo `auto_tax_dedution` -> `auto_tax_deduction` for
periodic-donation, prime-donation.