### PR TITLE
fix: /posts endpoint return 404 if post.caetgory_set is empty

### DIFF
--- a/internal/mongo/document.go
+++ b/internal/mongo/document.go
@@ -60,7 +60,10 @@ func BuildCategorySetStage() []bson.D {
 	var result []bson.D
 
 	// unwind category_set
-	result = append(result, bson.D{{Key: StageUnwind, Value: "$category_set"}})
+	result = append(result, bson.D{{Key: StageUnwind, Value: bson.D{
+		{Key: "path", Value: "$category_set"},
+		{Key: "preserveNullAndEmptyArrays", Value: true},
+	}}})
 
 	// lookup postcategories
 	result = append(result, bson.D{{Key: StageLookup, Value: bson.D{


### PR DESCRIPTION
# Related Issue
[沒有分類組合的文章，頁面會呈現 404](https://app.asana.com/0/0/1204213366816443/f)

# Root Cause
`$unwind` would drop record when target field is null ([ref](https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/#field-path-operand))

# Solution
add `preserveNullAndEmptyArrays` option to `$unwind` to preserve records.
