### PR TITLE
feat: support onboarding url on oauth & signin api

### DIFF
--- a/doc/auth.apib
+++ b/doc/auth.apib
@@ -2,6 +2,7 @@
 
 ### SigninRequest
 + email: user@example.com (required)
++ onboarding: https://accounts-twreporter.org/onboarding
 + destination: https://www.twreporter.org
 + errorRedirection: https://www.twreporter.org
 

--- a/doc/oauth.apib
+++ b/doc/oauth.apib
@@ -6,6 +6,7 @@ Redirect a user request to google oauth server
 ### Redirect google request [GET]
 + Parameters
     + destination: https://www.twreporter.org
+    + onboarding: https://accounts-twreporter.org/onboarding
 
 + Response 302
 
@@ -30,6 +31,7 @@ Redirect a user request to facebook oauth server
 
 + Parameters
     + destination: https://www.twreporter.org
+    + onboarding: https://accounts-twreporter.org/onboarding
 
 + Response 302
 


### PR DESCRIPTION
# Issue
[[會員制] 登入＆註冊的 flow：API 串接](https://app.asana.com/0/1203699264568808/1204699268404621/f)

# Notice
- oauth
  - add onboarding url if user activated && frontend provide onboarding parameter to oauth api
- auth by email
  - signin
    - same rule as `oauth`
  - authentication
    - do not add onboarding url even if onboarding parameter is provided

# Dependency
N/A

# Tbd
generate doc/index.html after approved