### PR TITLE
fix: move role mail from signin to setUser

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -91,19 +91,20 @@ func (mc *MembershipController) SetUser(c *gin.Context) (int, gin.H, error) {
 	if err != nil {
 		return http.StatusInternalServerError, gin.H{"status": "error", "message": "user does not exist"}, err
 	}
-	roleCheck, roleCheckErr := mc.Storage.HasRole(user, constants.RoleExplorer)
-	if roleCheckErr != nil {
-		log.Println("Error checking role:", roleCheckErr)
-	}
-
-	log.WithFields(log.Fields{
-		"user.Activated.Valid":         user.Activated.Valid,
-		"user.Activated.Time.IsZero()": user.Activated.Time.IsZero(),
-		"roleCheck":                    roleCheck,
-		"sendAssignRoleMail":           !user.Activated.Valid && user.Activated.Time.IsZero() && !roleCheck,
-	}).Info("SetUser Activated Role check")
 
 	if !user.Activated.Valid || user.Activated.Time.IsZero() {
+		roleCheck, roleCheckErr := mc.Storage.HasRole(user, constants.RoleExplorer)
+		if roleCheckErr != nil {
+			log.Println("Error checking role:", roleCheckErr)
+		}
+
+		log.WithFields(log.Fields{
+			"user.Activated.Valid":         user.Activated.Valid,
+			"user.Activated.Time.IsZero()": user.Activated.Time.IsZero(),
+			"roleCheck":                    roleCheck,
+			"sendAssignRoleMail":           !user.Activated.Valid && user.Activated.Time.IsZero() && !roleCheck,
+		}).Info("SetUser Activated Role check")
+
 		if !roleCheck {
 			go mc.sendAssignRoleMail(constants.RoleExplorer, user.Email.String)
 		}

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/twreporter/go-api/configs/constants"
 	"github.com/twreporter/go-api/globals"
 	"github.com/twreporter/go-api/models"
 )
@@ -82,6 +84,27 @@ func (mc *MembershipController) SetUser(c *gin.Context) (int, gin.H, error) {
 			return http.StatusBadRequest, gin.H{"status": "error", "message": "invalid maillist value"}, errors.New("Invalid maillist value")
 		}
 		maillists = append(maillists, convertedMaillist)
+	}
+
+	// send explorer role email for first time user
+	user, err := mc.Storage.GetUserByID(fmt.Sprint(userID))
+	if err != nil {
+		return http.StatusInternalServerError, gin.H{"status": "error", "message": "user does not exist"}, err
+	}
+	roleCheck, roleCheckErr := mc.Storage.HasRole(user, constants.RoleExplorer)
+	if roleCheckErr != nil {
+		log.Println("Error checking role:", roleCheckErr)
+	}
+
+	log.WithFields(log.Fields{
+		"user.Activated.Valid":         user.Activated.Valid,
+		"user.Activated.Time.IsZero()": user.Activated.Time.IsZero(),
+		"roleCheck":                    roleCheck,
+		"sendAssignRoleMail":           !user.Activated.Valid && user.Activated.Time.IsZero() && !roleCheck,
+	}).Info("SetUser Activated Role check")
+
+	if (!user.Activated.Valid || user.Activated.Time.IsZero()) && !roleCheck {
+		go mc.sendAssignRoleMail(constants.RoleExplorer, user.Email.String)
 	}
 
 	// Call UpdateReadPreferenceOfUser to save the preferences.ReadPreference to DB

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -103,8 +103,10 @@ func (mc *MembershipController) SetUser(c *gin.Context) (int, gin.H, error) {
 		"sendAssignRoleMail":           !user.Activated.Valid && user.Activated.Time.IsZero() && !roleCheck,
 	}).Info("SetUser Activated Role check")
 
-	if (!user.Activated.Valid || user.Activated.Time.IsZero()) && !roleCheck {
-		go mc.sendAssignRoleMail(constants.RoleExplorer, user.Email.String)
+	if !user.Activated.Valid || user.Activated.Time.IsZero() {
+		if !roleCheck {
+			go mc.sendAssignRoleMail(constants.RoleExplorer, user.Email.String)
+		}
 	}
 
 	// Call UpdateReadPreferenceOfUser to save the preferences.ReadPreference to DB


### PR DESCRIPTION
# Issue
The Explorer role mail should be sent if only the user is activated and not already an Explorer.
Due to activated which is set after onboarding, move role mail from signin to setUser.

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
