### PR TITLE
fix: only send Explorer role mail if is Explorer

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -94,7 +94,7 @@ func (mc *MembershipController) SetUser(c *gin.Context) (int, gin.H, error) {
 	log.WithFields(log.Fields{
 		"user.Activated.Valid":         user.Activated.Valid,
 		"user.Activated.Time.IsZero()": user.Activated.Time.IsZero(),
-		"sendAssignRoleMail":           !user.Activated.Valid && user.Activated.Time.IsZero(),
+		"sendAssignRoleMail":           !user.Activated.Valid || user.Activated.Time.IsZero(),
 	}).Info("SetUser Activated Role check")
 	if !user.Activated.Valid || user.Activated.Time.IsZero() {
 		go mc.sendAssignRoleMail(constants.RoleExplorer, user.Email.String)

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -102,10 +102,10 @@ func (mc *MembershipController) SetUser(c *gin.Context) (int, gin.H, error) {
 			"user.Activated.Valid":         user.Activated.Valid,
 			"user.Activated.Time.IsZero()": user.Activated.Time.IsZero(),
 			"roleCheck":                    roleCheck,
-			"sendAssignRoleMail":           !user.Activated.Valid && user.Activated.Time.IsZero() && !roleCheck,
+			"sendAssignRoleMail":           !user.Activated.Valid && user.Activated.Time.IsZero() && roleCheck,
 		}).Info("SetUser Activated Role check")
 
-		if !roleCheck {
+		if roleCheck {
 			go mc.sendAssignRoleMail(constants.RoleExplorer, user.Email.String)
 		}
 	}

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -91,23 +91,13 @@ func (mc *MembershipController) SetUser(c *gin.Context) (int, gin.H, error) {
 	if err != nil {
 		return http.StatusInternalServerError, gin.H{"status": "error", "message": "user does not exist"}, err
 	}
-
+	log.WithFields(log.Fields{
+		"user.Activated.Valid":         user.Activated.Valid,
+		"user.Activated.Time.IsZero()": user.Activated.Time.IsZero(),
+		"sendAssignRoleMail":           !user.Activated.Valid && user.Activated.Time.IsZero(),
+	}).Info("SetUser Activated Role check")
 	if !user.Activated.Valid || user.Activated.Time.IsZero() {
-		roleCheck, roleCheckErr := mc.Storage.HasRole(user, constants.RoleExplorer)
-		if roleCheckErr != nil {
-			log.Println("Error checking role:", roleCheckErr)
-		}
-
-		log.WithFields(log.Fields{
-			"user.Activated.Valid":         user.Activated.Valid,
-			"user.Activated.Time.IsZero()": user.Activated.Time.IsZero(),
-			"roleCheck":                    roleCheck,
-			"sendAssignRoleMail":           !user.Activated.Valid && user.Activated.Time.IsZero() && roleCheck,
-		}).Info("SetUser Activated Role check")
-
-		if roleCheck {
-			go mc.sendAssignRoleMail(constants.RoleExplorer, user.Email.String)
-		}
+		go mc.sendAssignRoleMail(constants.RoleExplorer, user.Email.String)
 	}
 
 	// Call UpdateReadPreferenceOfUser to save the preferences.ReadPreference to DB


### PR DESCRIPTION
# Issue
The Explorer role was assigned while user created.  So we should send role mail if it is explorer. (not blocking it)

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
