### PR TITLE
fix: add onboarding route & set cookie after onboarding

### DIFF
--- a/controllers/user.go
+++ b/controllers/user.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
-	"github.com/twreporter/go-api/configs/constants"
 	"github.com/twreporter/go-api/globals"
 	"github.com/twreporter/go-api/models"
 )
@@ -84,20 +82,6 @@ func (mc *MembershipController) SetUser(c *gin.Context) (int, gin.H, error) {
 			return http.StatusBadRequest, gin.H{"status": "error", "message": "invalid maillist value"}, errors.New("Invalid maillist value")
 		}
 		maillists = append(maillists, convertedMaillist)
-	}
-
-	// send explorer role email for first time user
-	user, err := mc.Storage.GetUserByID(fmt.Sprint(userID))
-	if err != nil {
-		return http.StatusInternalServerError, gin.H{"status": "error", "message": "user does not exist"}, err
-	}
-	log.WithFields(log.Fields{
-		"user.Activated.Valid":         user.Activated.Valid,
-		"user.Activated.Time.IsZero()": user.Activated.Time.IsZero(),
-		"sendAssignRoleMail":           !user.Activated.Valid || user.Activated.Time.IsZero(),
-	}).Info("SetUser Activated Role check")
-	if !user.Activated.Valid || user.Activated.Time.IsZero() {
-		go mc.sendAssignRoleMail(constants.RoleExplorer, user.Email.String)
 	}
 
 	// Call UpdateReadPreferenceOfUser to save the preferences.ReadPreference to DB

--- a/routers/router.go
+++ b/routers/router.go
@@ -199,6 +199,6 @@ func SetupRouter(cf *controllers.ControllerFactory) (engine *gin.Engine) {
 	v2AuthGroup.GET("/activate", middlewares.SetCacheControl("no-store"), mc.ActivateV2)
 	v2AuthGroup.POST("/token", middlewares.ValidateAuthentication(), middlewares.SetCacheControl("no-store"), ginResponseWrapper(mc.TokenDispatch))
 	v2AuthGroup.GET("/logout", mc.TokenInvalidate)
-	v2Group.POST("/onboarding/:userID", middlewares.ValidateAuthorization(), middlewares.SetCacheControl("no-store"), ginResponseWrapper(mc.Onboarding))
+	v2Group.POST("/onboarding/:userID", middlewares.ValidateAuthorization(), middlewares.ValidateUserID(), middlewares.SetCacheControl("no-store"), ginResponseWrapper(mc.Onboarding))
 	return
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -199,5 +199,6 @@ func SetupRouter(cf *controllers.ControllerFactory) (engine *gin.Engine) {
 	v2AuthGroup.GET("/activate", middlewares.SetCacheControl("no-store"), mc.ActivateV2)
 	v2AuthGroup.POST("/token", middlewares.ValidateAuthentication(), middlewares.SetCacheControl("no-store"), ginResponseWrapper(mc.TokenDispatch))
 	v2AuthGroup.GET("/logout", mc.TokenInvalidate)
+	v2Group.POST("/onboarding/:userID", middlewares.ValidateAuthorization(), middlewares.SetCacheControl("no-store"), ginResponseWrapper(mc.Onboarding))
 	return
 }


### PR DESCRIPTION
# Issue
[[維運] onboarding 完，沒辦法維持登入狀態
](https://app.asana.com/0/1203699264568808/1205329976326260/f)
- add `/v2/onboarding` route & set `activated` cookie in response

# Notice
- api doc & test would be updated in next PR

# Dependency
N/A
