### PR TITLE
fix: quick fix oAuth authentication failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+### 7.3.2
+
+### Notable Changes
+
+- Fixes
+  - "oauth fails due to database operation error:: Error 1406: Data too long for column 'picture' at row 1" error.
+
+### Commits
+* \[[`7ae0a04317`](https://github.com/twreporter/go-api/commit/7ae0a04317)] - **fix**: quick fix oAuth authentication failures (nickhsine)
+
+
 ## Released
 
 ### 7.3.1 (Current)

--- a/controllers/oauth.go
+++ b/controllers/oauth.go
@@ -38,17 +38,17 @@ type facebookOauthInfoRaw struct {
 	AId        null.String `json:"id"`
 	FirstName  null.String `json:"first_name"`
 	LastName   null.String `json:"last_name"`
-	PictureObj struct {
-		Data struct {
-			URL null.String `json:"url"`
-		} `json:"data"`
-	} `json:"picture"`
+	//PictureObj struct {
+	//  Data struct {
+	//    URL null.String `json:"url"`
+	//  } `json:"data"`
+	//} `json:"picture"`
 }
 
 // Picture is used by copier to copy PictureObj.Data.URL field to Picture field
-func (info *facebookOauthInfoRaw) Picture() null.String {
-	return info.PictureObj.Data.URL
-}
+//func (info *facebookOauthInfoRaw) Picture() null.String {
+//  return info.PictureObj.Data.URL
+//}
 
 func (info *facebookOauthInfoRaw) Gender() null.String {
 	return utils.GetGender(info.basicInfo.Gender)
@@ -59,7 +59,7 @@ type googleOauthInfoRaw struct {
 	AId       null.String `json:"sub"`
 	FirstName null.String `json:"given_name"`
 	LastName  null.String `json:"family_name"`
-	Picture   null.String `json:"picture"`
+	// Picture   null.String `json:"picture"`
 }
 
 func (info *googleOauthInfoRaw) Gender() null.String {


### PR DESCRIPTION
# Issue
Some users can not pass oAuth authentication due to 
"oauth fails due to database operation error:: Error 1406: Data too long for column 'picture' at row 1" error.
Here are the error logs:
https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22coastal-run-106202%22%0Aresource.labels.location%3D%22asia-east1%22%0Aresource.labels.cluster_name%3D%22twreporter%22%0Aresource.labels.namespace_name%3D%22production%22%0Alabels.k8s-pod%2Frun%3D%22go-api%22%20severity%3E%3DDEFAULT%0AjsonPayload.message%3D%22oauth%20fails%20due%20to%20database%20operation%20error::%20Error%201406:%20Data%20too%20long%20for%20column%20'picture'%20at%20row%201%22;cursorTimestamp=2023-09-01T13:40:11.410352139Z;aroundTime=2023-09-01T13:40:11.410352139Z;duration=PT15S?project=coastal-run-106202


# Notice
This is a workaround.
We should do DB migration to increase `picture` `varchar(255)` to bigger size.
