### PR TITLE
fix: only send role mail after success payment

### DIFF
--- a/controllers/donation.go
+++ b/controllers/donation.go
@@ -1115,6 +1115,38 @@ func (mc *MembershipController) PatchLinePayOfAUser(c *gin.Context) (int, gin.H,
 
 		go mc.sendDonationThankYouMail(*mail)
 
+		// Concurrently update the user's activated time
+		go func(email string) {
+			matchedUser, err := mc.Storage.GetUserByEmail(email)
+			if nil != err {
+				log.Errorf("Error retrieving user data: %v", err)
+				return
+			}
+
+			matchedUser.Activated = null.TimeFrom(time.Now())
+			err = mc.Storage.UpdateUser(matchedUser)
+			if nil != err {
+				log.Errorf("Error updating user activated time: %v", err)
+			}
+
+			// Call AssignRoleToUser to assign role to user
+			HasTrailblazer, err := mc.Storage.HasRole(matchedUser, constants.RoleTrailblazer)
+			if err != nil {
+				log.Errorf("Error checking user roles: %v", err)
+			}
+			if !HasTrailblazer {
+				roleCheck, _ := mc.Storage.HasRole(matchedUser, constants.RoleActionTaker)
+				err = mc.Storage.AssignRoleToUser(matchedUser, constants.RoleActionTaker)
+				if err != nil {
+					log.Errorf("Error updating user role: %v", err)
+				}
+
+				if !roleCheck {
+					go mc.sendAssignRoleMail(constants.RoleActionTaker, email)
+				}
+			}
+		}(updateData.Cardholder.Email)
+
 		// publish to cloud pub/sub
 		ms := []*cloudpub.Message{
 			&cloudpub.Message{


### PR DESCRIPTION
# Issue
The role mail will be sent even if LinePay failed.
Fix the issue by send mail only after `primeDonation.Status == statusPaid`

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
