### PR TITLE
fix: wrong email subscription url in success-donation.tmpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,13 @@
 
 ## Released
 
-### 7.3.6 (Current)
+### 7.3.7 (Current)
+
+#### Commits
+
+* [[`36bd9591bb`](https://github.com/twreporter/go-api/commit/36bd9591bb)] - **fix**: wrong email subcription url in success-donation.tmpl (nickhsine)
+
+### 7.3.6
 
 #### Notable Changes
 
@@ -60,7 +66,7 @@
 
 #### Commits
 
-- [[`8b1a04b`](https://github.com/twreporter/go-api/8b1a04b)] - **fix**: typo in trailblazer template
+- [[`8b1a04b`](https://github.com/twreporter/go-api/commit/8b1a04b)] - **fix**: typo in trailblazer template
 
 ### 7.3.5
 
@@ -85,7 +91,7 @@
 
 #### Commits
 
-- [[`ead8276121`](https://github.com/twreporter/go-api/ead8276121)] - **fix**: CHANGELOG.md wording (Aylie Chou)
+- [[`ead8276121`](https://github.com/twreporter/go-api/commit/ead8276121)] - **fix**: CHANGELOG.md wording (Aylie Chou)
 - [[`86fc18ac7e`](https://github.com/twreporter/go-api/commit/86fc18ac7e)] - **chore**: update doc html (Aylie Chou)
 - [[`9b31bd6cbc`](https://github.com/twreporter/go-api/commit/9b31bd6cbc)] - **chore**: update user api doc (Aylie Chou)
 - [[`65235d26e6`](https://github.com/twreporter/go-api/commit/65235d26e6)] - **chore**: add migration files (Aylie Chou)

--- a/template/success-donation.tmpl
+++ b/template/success-donation.tmpl
@@ -1170,7 +1170,7 @@
 
 
 																																						<td align="left" valign="middle" class="mcnFollowTextContent" style="padding-left:5px;">
-																																							<a href="https://twreporter.us14.list-manage.com/subscribe/post?u=4da5a7d3b98dbc9fdad009e7e&amp;id=e0eb0c8c32" target=""
+																																							<a href="https://www.twreporter.org/account/email-subscription" target=""
 																																							    style="font-family: &quot;Source Sans Pro&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif;font-size: 13px;text-decoration: none;color: #262626;font-weight: bold;">訂閱電子報</a>
 																																						</td>
 


### PR DESCRIPTION
# Issue
贊助成功信件的「訂閱電子報」連結失效，需要替換成新的網址。
https://app.asana.com/0/0/1206211289316588/f
