### PR TITLE
fix: `/post_followups` would return empty data

### DIFF
--- a/internal/mongo/document.go
+++ b/internal/mongo/document.go
@@ -171,6 +171,9 @@ func BuildFollowupLookupStatements(offset int, limit int) []bson.D {
 			{Key: "state", Value: "published"},
 			{Key: "followup", Value: bson.D{
 				{Key: OpExists, Value: true},
+				{Key: OpNot, Value: bson.D{
+					{Key: OpSize, Value: 0},
+				}},
 			}},
 		},
 	}})

--- a/internal/mongo/operator.go
+++ b/internal/mongo/operator.go
@@ -14,6 +14,8 @@ const (
 	OpExists       = "$exists"
 	OpNe           = "$ne"
 	OpCount        = "$count"
+	OpNot          = "$not"
+	OpSize         = "$size"
 
 	OrderAsc  = 1
 	OrderDesc = -1


### PR DESCRIPTION
# Issue
[[defect] 我的閱讀頁存在後台不存在的後續追蹤內容](https://app.asana.com/0/1203699264568808/1207764753093382/f)

# Notice
- `$exists: true` would return empty array, need to add `$not: { $size: 0 }` rule

# Dependency
N/A
