### PR TITLE
fix: remove text decoration style in chrome

### DIFF
--- a/template/signin-otp.tmpl
+++ b/template/signin-otp.tmpl
@@ -1014,6 +1014,9 @@
                                                                                             ><a
                                                                                                 href="https://www.twreporter.org/"
                                                                                                 target="_blank"
+                                                                                                style="
+                                                                                                    text-decoration: none;
+                                                                                                "
                                                                                                 ><span
                                                                                                     style="
                                                                                                         color: #404040;
@@ -1032,6 +1035,9 @@
                                                                                         ><a
                                                                                                 href="mailto:events@twreporter.org"
                                                                                                 target="_blank"
+                                                                                                style="
+                                                                                                    text-decoration: none;
+                                                                                                "
                                                                                                 ><span
                                                                                                     style="
                                                                                                         color: #404040;
@@ -1047,6 +1053,9 @@
                                                                                             ><a
                                                                                                 href="https://support.twreporter.org/"
                                                                                                 target="_blank"
+                                                                                                style="
+                                                                                                    text-decoration: none;
+                                                                                                "
                                                                                                 ><span
                                                                                                     style="
                                                                                                         color: #404040;


### PR DESCRIPTION
# Issue
[[defect] footer的文字超連結不應有底線](https://app.asana.com/0/1203699264568808/1208279921606021/f)

# Dependency
N/A
