### PR TITLE
fix: add `Host` header for IAP issue

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -88,8 +88,9 @@ mailchimp:
         operational_journal: ca9d491549 # 報導者營運手記
 features:
     enable_rolemail: false
-memberCMS:
+membercms:
     url: '' # graphQL server url
+    host: '' # graphql server hostname
     email: '' # headless account email
     password: '' # headless account password
 `)
@@ -227,6 +228,7 @@ type FeaturesConfig struct {
 
 type MemberCMSConfig struct {
 	Url      string `yaml:"url"`
+	Host     string `yaml:"host"`
 	Email    string `yaml:"email"`
 	Password string `yaml:"password"`
 }
@@ -329,9 +331,10 @@ func buildConf() ConfYaml {
 	conf.Features.EnableRolemail = viper.GetBool("features.enable_rolemail")
 
 	// Member cms config
-	conf.MemberCMS.Url = viper.GetString("memberCMS.url")
-	conf.MemberCMS.Email = viper.GetString("memberCMS.email")
-	conf.MemberCMS.Password = viper.GetString("memberCMS.password")
+	conf.MemberCMS.Url = viper.GetString("membercms.url")
+	conf.MemberCMS.Host = viper.GetString("membercms.host")
+	conf.MemberCMS.Email = viper.GetString("membercms.email")
+	conf.MemberCMS.Password = viper.GetString("membercms.password")
 
 	return conf
 }

--- a/internal/graphql/method.go
+++ b/internal/graphql/method.go
@@ -32,6 +32,7 @@ func NewClient() error {
 func Query(req *Request) (interface{}, error) {
 	cookie := getCookie()
 	req.Header.Set("Cookie", cookie)
+	req.Header.Set("Host", globals.Conf.MemberCMS.Host)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*constants.MemberCMSQueryTimeout)
 	defer cancel()
 
@@ -60,6 +61,7 @@ func refreshToken() error {
 	req.Var("email", globals.Conf.MemberCMS.Email)
 	req.Var("password", globals.Conf.MemberCMS.Password)
 	req.Header.Set("Cache-Control", "no-store")
+	req.Header.Set("Host", globals.Conf.MemberCMS.Host)
 
 	if err := client.Run(context.Background(), req, &respData); err != nil {
 		return err


### PR DESCRIPTION
# Issue
[[會員管理 CMS GQL] 產生內部 ip，讓 go-api 可以走內網 request GQL server，以避免 IAP 阻擋。 
](https://app.asana.com/0/1205812314629275/1208386531521148/f)

# Dependency
related to kybernetes-config [#65](https://github.com/twreporter/kubernetes-config/pull/65)
