### PR TITLE
fix: use `Header.Set` instead of `Header.Add` for testing

### DIFF
--- a/internal/graphql/client.go
+++ b/internal/graphql/client.go
@@ -126,7 +126,7 @@ func (c *Client) runWithJSON(ctx context.Context, req *Request, resp interface{}
 	r.Header.Set("Accept", "application/json; charset=utf-8")
 	for key, values := range req.Header {
 		for _, value := range values {
-			r.Header.Add(key, value)
+			r.Header.Set(key, value)
 		}
 	}
 	c.logf(">> headers: %v", r.Header)


### PR DESCRIPTION
# Issue
address IAP isuue in [[電子收據] go-api 對接 member cms ](https://app.asana.com/0/1203699264568808/1208301216504807/f)

# Notice
ref: http package [doc](https://pkg.go.dev/net/http#Header.Set)

# Dependency
N/A
