### PR TITLE
fix: get filename from donation type

### DIFF
--- a/controllers/donation.go
+++ b/controllers/donation.go
@@ -517,20 +517,15 @@ func (mc *MembershipController) sendDonationThankYouMail(body clientResp) {
 	var donationLink string = origin + "/contribute/" + body.Frequency + "/" + body.OrderNumber + "?utm_source=supportsuccess&utm_medium=email"
 
 	var donationType string
-	var donationTypeEn string
 	switch body.Frequency {
 	case oneTimeFrequency:
 		donationType = "單筆捐款"
-		donationTypeEn = "prime"
 	case monthlyFrequency:
 		donationType = "定期定額"
-		donationTypeEn = "periodic"
 	case yearlyFrequency:
 		donationType = "定期定額"
-		donationTypeEn = "periodic"
 	default:
 		donationType = "捐款"
-		donationTypeEn = "periodic"
 	}
 
 	reqBody := donationSuccessReqBody{
@@ -538,7 +533,6 @@ func (mc *MembershipController) sendDonationThankYouMail(body clientResp) {
 		Currency:       body.Currency,
 		DonationMethod: payMethodMap[body.PayMethod],
 		DonationType:   donationType,
-		DonationTypeEn: donationTypeEn,
 		DonationLink:   donationLink,
 		Email:          body.Cardholder.Email,
 		Name:           body.Cardholder.Name.ValueOrZero(),

--- a/controllers/mail.go
+++ b/controllers/mail.go
@@ -36,7 +36,6 @@ type donationSuccessReqBody struct {
 	DonationLink      string   `json:"donation_link" binding:"required"`
 	DonationMethod    string   `json:"donation_method" binding:"required"`
 	DonationType      string   `json:"donation_type" binding:"required"`
-	DonationTypeEn    string   `json:"donation_type_en" binding:"required"`
 	Email             string   `json:"email" binding:"required"`
 	IsAutoPay         bool     `json:"is_auto_pay"`
 	Name              string   `json:"name"`
@@ -189,6 +188,7 @@ func (contrl *MailController) SendDonationSuccessMail(c *gin.Context) (int, gin.
 	}
 
 	location, _ = time.LoadLocation(taipeiLocationName)
+	donationTypeEn := getDonationTypeEn(reqBody.DonationType)
 
 	var templateData = struct {
 		donationSuccessReqBody
@@ -204,7 +204,7 @@ func (contrl *MailController) SendDonationSuccessMail(c *gin.Context) (int, gin.
 		fmt.Sprintf("%d", time.Now().Year()),
 	}
 
-	templateName := fmt.Sprintf("success-donation-%s.tmpl", reqBody.DonationTypeEn)
+	templateName := fmt.Sprintf("success-donation-%s.tmpl", donationTypeEn)
 	if err = contrl.HTMLTemplate.ExecuteTemplate(&out, templateName, templateData); err != nil {
 		return http.StatusInternalServerError, gin.H{"status": "error", "message": "can not create donation success mail body"}, errors.WithStack(err)
 	}
@@ -312,4 +312,13 @@ func postMailServiceEndpoint(reqBody interface{}, endpoint string) error {
 	}
 
 	return nil
+}
+
+func getDonationTypeEn(donationType string) string {
+	switch donationType {
+	case "單筆捐款":
+		return "prime"
+	default:
+		return "periodic"
+	}
 }


### PR DESCRIPTION
# Issue
`pangolin` cannot send thank you mail
[[defect] 修復定期定額第二次之後的扣款通知](https://www.notion.so/twreporter/Copyright-2025-67bdec71d7eb42ef9626cae84d013cd7?pvs=4)

# Notice
- #789 adds new required parameter `donation_type_en` for thank you mail endpoint, but pangolin do not add it in request.

# Dependency
N/A
